### PR TITLE
v0.2.0 update

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,13 @@ jobs:
           curl -O https://raw.githubusercontent.com/cpplint/cpplint/ab7335bcc734f6d21226631060888bfb77bbc9d7/cpplint.py
 
       - name: Lint cpplint-cpp
-        run: python benchmark.py . --cpplint_cpp="./build/cpplint-cpp"
+        run: |
+          python benchmark.py . --cpplint_cpp="./build/cpplint-cpp"
+          sh memory_usage.sh "python cpplint.py" .
+          sh memory_usage.sh "./build/cpplint-cpp" .
 
       - name: Lint googletest
-        run: python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./build/cpplint-cpp"
+        run: |
+          python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./build/cpplint-cpp"
+          sh memory_usage.sh "python cpplint.py" ../googletest-${{ env.GTEST_VER }}
+          sh memory_usage.sh "./build/cpplint-cpp" ../googletest-${{ env.GTEST_VER }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,6 +29,11 @@ jobs:
           cp -r subprojects/googletest-${{ env.GTEST_VER }} ../
           curl -O https://raw.githubusercontent.com/cpplint/cpplint/ab7335bcc734f6d21226631060888bfb77bbc9d7/cpplint.py
 
+      - name: Show CPU info
+        run: |
+          lscpu
+          ./build/cpplint-cpp --threads=
+
       - name: Lint cpplint-cpp
         run: |
           python benchmark.py . --cpplint_cpp="./build/cpplint-cpp"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,4 +33,4 @@ jobs:
         run: python benchmark.py . --cpplint_cpp="./build/cpplint-cpp"
 
       - name: Lint googletest
-        run: python benchmark.py ../googletest-${{ env.GTEST_VER }}/googletest --cpplint_cpp="./build/cpplint-cpp"
+        run: python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./build/cpplint-cpp"

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 build*
 *.exe
 *.bat
-!batch_files/*.bat
 *.sh
+!memory_usage.sh
 *.txt
 !meson_options.txt
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,27 @@ It used to be developed and maintained by Google Inc. One of its forks now maint
 
 ## cpplint-cpp vs. cpplint.py
 
-Here is an analysis of the execution times between `cpplint-cpp` and `cpplint.py` against two repositories:
+Here is an analysis of the performance differences between `cpplint-cpp` and `cpplint.py` against two repositories:
 [`googletest`](https://github.com/google/googletest) and `cpplint-cpp`.
 Measurements were taken on an Ubuntu runner with [`benchmark.yml`](.github/workflows/benchmark.yml).
 
+### Execution time
+
+You can see `cpplint-cpp` has significantly better performance, being over 30 times faster than `cpplint.py`.
+
 |             | googletest-1.14.0 (s) | cpplint-cpp (s) |
 | ----------- | --------------------- | --------------- |
-| cpplint-cpp | 0.785884              | 0.188663        |
-| cpplint.py  | 14.165049             | 3.439704        |
+| cpplint-cpp | 0.530342              | 0.106502        |
+| cpplint.py  | 25.555369             | 3.526787        |
+
+### Memory usage
+
+Despite using multithreading with 4 cores, `cpplint-cpp` has lower memory usage than `cpplint.py`.
+
+|             | googletest-1.14.0 | cpplint-cpp |
+| ----------- | ----------------- | ----------- |
+| cpplint-cpp | 15.61 MiB         | 10.07 MiB   |
+| cpplint.py  | 22.98 MiB         | 22.20 MiB   |
 
 ## Changes from cpplint.py
 
@@ -26,7 +39,10 @@ Basically, `cpplint-cpp` uses the same algorithm as `cpplint.py`, but some chang
 
 - Added concurrent file processing.
 - Removed some redundant function calls.
+- Used JIT compiler for some regex patterns.
 - Combined some regex patterns.
+- Added `--timing` option to display the execution time.
+- Added `--threads=` option to specify the number of threads.
 - And other minor changes for optimization...
 
 ## Unimplemented features

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,13 @@ def measure_time(command, repeat_time=30):
     count = 0
     while(duration < repeat_time):
         start_time = time.time()  # Record start time
-        result = subprocess.run(command, shell=True)  # Execute the command
+        # Execute the command
+        if count == 0:
+            subprocess.run(command, shell=True)
+        else:
+            subprocess.run(
+                command, shell=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         end_time = time.time()  # Record end time
         duration += end_time - start_time
         count += 1
@@ -44,14 +50,13 @@ if __name__ == '__main__':
         cmd_cpp = cmd_cpp.replace("/", "\\")
         cmd_py = cmd_py.replace("/", "\\")
 
-    # Measure time for cpplint-cpp
+    # Measuring
     print(f"Measuring time for cpplint-cpp: {cmd_cpp}")
     time1 = measure_time(cmd_cpp, repeat_time)
 
-    # Measure time for cpplint-py
     print(f"Measuring time for cpplint.py: {cmd_py}")
     time2 = measure_time(cmd_py, repeat_time)
 
     # Output result
     print(f"Execution time for cpplint-cpp: {time1:.6f} seconds")
-    print(f"Execution time for cpplint-py: {time2:.6f} seconds")
+    print(f"Execution time for cpplint.py: {time2:.6f} seconds")

--- a/include/cleanse.h
+++ b/include/cleanse.h
@@ -7,7 +7,8 @@
 
 extern const regex_code RE_PATTERN_INCLUDE;
 
-extern const regex_code RE_PATTERN_ALT_TOKEN_REPLACEMENT;
+// Get regex pattern for RE_PATTERN_ALT_TOKEN_REPLACEMENT
+std::string GetReAltTokenReplacement();
 
 // ALT_TOKEN_REPLACEMENT[alt_token]
 const std::string& AltTokenToToken(const std::string& alt_token);

--- a/include/cleanse.h
+++ b/include/cleanse.h
@@ -27,8 +27,7 @@ const std::string& AltTokenToToken(const std::string& alt_token);
 bool IsCppString(const std::string& line);
 
 // Removes //-comments and single-line C-style /* */ comments.
-std::string CleanseComments(const std::string& line, bool* is_comment,
-                            regex_match& re_result_temp);
+std::string CleanseComments(const std::string& line, bool* is_comment);
 
 class CleansedLines {
     /*Holds 4 copies of all lines with different preprocessing applied to them.

--- a/include/cpplint_state.h
+++ b/include/cpplint_state.h
@@ -52,6 +52,8 @@ class CppLintState {
 
     std::mutex m_mtx;
 
+    int m_num_threads;
+
  public:
     CppLintState();
 
@@ -106,6 +108,9 @@ class CppLintState {
 
     int ErrorCount() const { return m_error_count; }
     int ErrorCount(const std::string& category) const;
+
+    void SetNumThreads(int num_threads) { m_num_threads = num_threads; }
+    int GetNumThreads() const { return m_num_threads; }
 
     // Bumps the module's error statistic.
     void IncrementErrorCount(const std::string& category);

--- a/include/cpplint_state.h
+++ b/include/cpplint_state.h
@@ -116,6 +116,9 @@ class CppLintState {
                const std::string& category, int confidence,
                const std::string& message);
 
+    // Flush buffers for cout and cerr
+    void FlushThreadStream();
+
     // Print a summary of errors by category, and the total.
     void PrintErrorCounts();
     void PrintInfo(const std::string& message);

--- a/include/file_linter.h
+++ b/include/file_linter.h
@@ -27,7 +27,6 @@ class FileLinter {
     fs::path m_file_from_repo;  // relative path from repository
     std::string m_cppvar;
     regex_match m_re_result;
-    regex_match m_re_result_temp;  // use this when we dont need results
     bool m_has_error;
 
  public:
@@ -45,7 +44,6 @@ class FileLinter {
                 m_file_from_repo(),
                 m_cppvar(),
                 m_re_result(RegexCreateMatchData(16)),
-                m_re_result_temp(RegexCreateMatchData(16)),
                 m_has_error(false) {}
 
     fs::path GetRelativeFromRepository(const fs::path& file, const fs::path& repository);

--- a/include/regex_utils.h
+++ b/include/regex_utils.h
@@ -55,11 +55,21 @@ PCRE2_SIZE GetMatchSize(regex_match& match, int i) noexcept;
 pcre2_code* RegexCompileBase(const std::string& regex,
                              uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept;
 
+// get pcre2_code as a unique pointer
 inline regex_code RegexCompile(const std::string& regex,
                                uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept {
     pcre2_code* ret = RegexCompileBase(regex, options);
     return regex_code(ret);
 }
+
+#ifdef SUPPORT_JIT
+// Uses jit compiler for regex
+// It makes matching faster when using complex patterns in RegexSearch.
+regex_code RegexJitCompile(const std::string& regex,
+                           uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept;
+#else
+#define RegexJitCompile(...) RegexCompile(__VA_ARGS__)
+#endif
 
 // ovecsize is the number of groups plus one.
 inline regex_match RegexCreateMatchData(uint32_t ovecsize) noexcept {

--- a/include/states.h
+++ b/include/states.h
@@ -37,14 +37,12 @@ class IncludeState {
     int m_section;
     std::string m_last_header;
     std::vector<std::vector<std::pair<std::string, size_t>>> m_include_list;
-    regex_match m_re_result;
 
  public:
     IncludeState() :
         m_section(0),
         m_last_header(""),
-        m_include_list({{}}),
-        m_re_result(RegexCreateMatchData(8)) {
+        m_include_list({{}}) {
         ResetSection("");
     }
 
@@ -157,15 +155,13 @@ class NestingState {
     // Stack of _PreprocessorInfo objects.
     std::stack<PreprocessorInfo> m_pp_stack;
     regex_match m_re_result;
-    regex_match m_re_result_temp;
 
  public:
     NestingState() :
         m_stack({}),
         m_previous_stack_top(nullptr),
         m_pp_stack(),
-        m_re_result(RegexCreateMatchData(16)),
-        m_re_result_temp(RegexCreateMatchData(16)) {}
+        m_re_result(RegexCreateMatchData(16)) {}
 
     ~NestingState() {
         // Free block info objects

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -47,7 +47,8 @@ std::vector<std::string> StrSplitBy(const std::string &str, const std::string &d
 std::set<std::string> ParseCommaSeparetedList(const std::string& str);
 
 // Concat vec2 to vec1.
-inline void ConcatVec(std::vector<std::string>& vec1, std::vector<std::string>& vec2) {
+template <typename T>
+inline void ConcatVec(std::vector<T>& vec1, std::vector<T>& vec2) {
     vec1.insert(vec1.end(), vec2.begin(), vec2.end());
 }
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -94,6 +94,10 @@ inline bool StrContain(const std::string& str, const char c) {
     return str.find(c) != std::string::npos;
 }
 
+inline bool StrContain(const std::string& str, const char c, size_t pos) {
+    return str.find(c, pos) != std::string::npos;
+}
+
 inline bool StrIsChar(const std::string& str, char c) {
     return str.size() == 1 && str[0] == c;
 }
@@ -118,10 +122,10 @@ std::string StrToLower(const std::string &str);
 std::string StrToUpper(const std::string &str);
 
 // Returns the first non-space character or a null terminator.
-char GetFirstNonSpace(const std::string& str) noexcept;
+char GetFirstNonSpace(const std::string& str, size_t pos = 0) noexcept;
 
 // Returns index to the first non-space character or INDEX_NONE.
-size_t GetFirstNonSpacePos(const std::string& str) noexcept;
+size_t GetFirstNonSpacePos(const std::string& str, size_t pos = 0) noexcept;
 
 // Returns true if the string is empty or consists of only white spaces.
 inline bool StrIsBlank(const std::string& str) noexcept {

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -37,6 +37,9 @@ size_t StrLstripSize(const std::string &str);
 // Split string by white spaces. Empty strings are removed from return value.
 std::vector<std::string> StrSplit(const std::string& str, size_t max_size = INDEX_MAX);
 
+// StrSplit().back()
+std::string StrSplitLast(const std::string& str);
+
 // Split string by another string.
 std::vector<std::string> StrSplitBy(const std::string &str, const std::string &delimiter);
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -86,6 +86,10 @@ inline bool StrContain(const std::string& str, const std::string& target) {
     return str.find(target) != std::string::npos;
 }
 
+inline bool StrContain(const std::string& str, const char* target) {
+    return str.find(target) != std::string::npos;
+}
+
 inline bool StrContain(const std::string& str, const char c) {
     return str.find(c) != std::string::npos;
 }

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -16,6 +16,9 @@ std::string StrStrip(const std::string &str);
 // Strips leading and tailing characters from a string.
 std::string StrStrip(const std::string &str, char c);
 
+// Strips leading spaces from start and tailing spaces from end.
+std::string StrStrip(const char* start, const char* end);
+
 // Strips tailing white spaces from a string.
 std::string StrRstrip(const std::string &str);
 

--- a/memory_usage.sh
+++ b/memory_usage.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Script to measure memory usage with cpplint
+#
+# Examples
+#  sh memory_usage.sh "python3 cpplint.py" .
+#  sh memory_usage.sh "./build/cpplint-cpp" ../googletest-1.4.0
+
+echo Measuring memory usage...
+kib="$(/usr/bin/time -f "%M" sh -c "$1 --recursive --quiet --counting=detailed $2 >/dev/null 2>&1 || exit 0" 2>&1)"
+mib=$(echo "scale=2; $kib / 1024" | bc)
+echo Maximum memory usage: ${mib} MiB

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ project('cpplint-cpp', ['c', 'cpp'],
 cpplint_link_args = []
 cpplint_c_args = []
 cpplint_os = host_machine.system()
+cpplint_cpu = host_machine.cpu_family()
 cpplint_compiler = meson.get_compiler('c').get_id()
 cpplint_is_debug = get_option('buildtype').startswith('debug')
 
@@ -64,11 +65,15 @@ endif
 
 # enable JIT compiler in pcre2
 cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
-pcre2_jit_supported = (target_machine.cpu_family() in cpu_jit_supported and
-                       meson.get_compiler('c').get_id() != 'tcc' and
-                       target_machine.system() != 'darwin')
+pcre2_jit_supported = (cpplint_cpu in cpu_jit_supported and
+                       cpplint_compiler != 'tcc' and
+                       cpplint_os != 'darwin')
 if pcre2_jit_supported
-    add_global_arguments('/DSUPPORT_JIT', language: ['c', 'cpp'])
+    if cpplint_compiler == 'msvc'
+        add_global_arguments('/DSUPPORT_JIT', language: ['c', 'cpp'])
+    else
+        add_global_arguments('-DSUPPORT_JIT', language: ['c', 'cpp'])
+    endif
 endif
 
 # get pcre2

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,15 @@ elif cpplint_os == 'darwin'
     endif
 endif
 
+# enable JIT compiler in pcre2
+cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
+pcre2_jit_supported = (target_machine.cpu_family() in cpu_jit_supported and
+                       meson.get_compiler('c').get_id() != 'tcc' and
+                       target_machine.system() != 'darwin')
+if pcre2_jit_supported
+    add_global_arguments('/DSUPPORT_JIT', language: ['c', 'cpp'])
+endif
+
 # get pcre2
 pcre2_options = [
     'grep=false',

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project('cpplint-cpp', ['c', 'cpp'],
         'cpp_winlibs=',                 # likewise as with c_winlibs
         'wrap_mode=forcefallback'       # we don't use installed libraries.
     ],
-    version: '0.1.0')
+    version: '0.2.0')
 
 cpplint_link_args = []
 cpplint_c_args = []

--- a/src/cleanse.cpp
+++ b/src/cleanse.cpp
@@ -54,7 +54,8 @@ std::string GetReAltTokenReplacement() {
 }
 
 const regex_code RE_PATTERN_INCLUDE = RegexCompile(R"(^\s*#\s*include\s*([<"])([^>"]*)[>"].*$)");
-const regex_code RE_PATTERN_ALT_TOKEN_REPLACEMENT = RegexCompile(GetReAltTokenReplacement());
+static const regex_code RE_PATTERN_ALT_TOKEN_REPLACEMENT =
+    RegexCompile(GetReAltTokenReplacement());
 
 std::vector<std::string>
 CleansedLines::CleanseRawStrings(const std::vector<std::string>& raw_lines) {

--- a/src/cleanse.cpp
+++ b/src/cleanse.cpp
@@ -249,7 +249,7 @@ std::string CleansedLines::CollapseStrings(const std::string& elided) {
             like "0.'3" (gcc 4.9.0 will not allow this literal).
             */
             static const regex_code RE_PATTERN_DIGIT =
-                RegexCompile(R"(\b(?:0[bBxX]?|[1-9])[0-9a-fA-F]*$)");
+                RegexJitCompile(R"(\b(?:0[bBxX]?|[1-9])[0-9a-fA-F]*$)");
             if (RegexSearch(RE_PATTERN_DIGIT, head, m_re_result)) {
                 std::string subject = "'" + tail;
                 static const regex_code RE_PATTERN_DIGIT2 =

--- a/src/cleanse.cpp
+++ b/src/cleanse.cpp
@@ -274,7 +274,7 @@ CleansedLines::CleansedLines(std::vector<std::string>& lines,
                              m_raw_lines(lines),
                              m_has_comment(lines.size(), false),
                              m_re_result(RegexCreateMatchData(16)) {
-    if (InStrVec(options.Filters(), "-readability/alt_tokens")) {
+    if (!options.ShouldPrintError("readability/alt_tokens", "", INDEX_NONE)) {
         for (std::string& line : m_raw_lines) {
             line = ReplaceAlternateTokens(line);
         }

--- a/src/cpplint_state.cpp
+++ b/src/cpplint_state.cpp
@@ -15,7 +15,8 @@ CppLintState::CppLintState() :
     m_counting(COUNT_TOTAL),
     m_errors_by_category({}),
     m_quiet(false),
-    m_output_format(OUTPUT_EMACS) {}
+    m_output_format(OUTPUT_EMACS),
+    m_num_threads(0) {}
 
 void CppLintState::IncrementErrorCount(const std::string& category) {
     std::string cat = category;

--- a/src/cpplint_state.cpp
+++ b/src/cpplint_state.cpp
@@ -59,7 +59,7 @@ thread_local std::ostringstream cout_buffer;
 thread_local std::ostringstream cerr_buffer;
 
 // Flush streams when the buffer size is larger than this value
-constexpr size_t FLUSH_THRESHOLD = 512;
+static const std::streampos FLUSH_THRESHOLD = 512;
 
 void CppLintState::PrintInfo(const std::string& message) {
     // _quiet does not represent --quiet flag.

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -3383,7 +3383,7 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
     const std::string& base_classname = classinfo->Basename();
 
     // Since the next regex function can be a bottleneck,
-    // we check if the calss name exists or not.
+    // we check if the class name exists or not.
     if (!StrContain(elided, base_classname))
         return;
 

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -35,7 +35,7 @@ void FileLinter::CheckForCopyright(const std::vector<std::string>& lines) {
     static const regex_code RE_PATTERN_COPYRIGHT =
         RegexCompile("Copyright", REGEX_OPTIONS_ICASE);
     for (size_t i = 1; i < MIN(lines.size(), 11); i++) {
-        if (RegexSearch(RE_PATTERN_COPYRIGHT, lines[i], m_re_result_temp)) {
+        if (RegexSearch(RE_PATTERN_COPYRIGHT, lines[i])) {
             return;
         }
     }
@@ -205,9 +205,9 @@ void FileLinter::ProcessGlobalSuppressions(const std::string& line) {
                      R"(vim?:\s*.*(\s*|:)filetype=c(\s*|:|$)))");
     static const regex_code RE_SEARCH_KERNEL_FILE =
         RegexCompile(R"(\b(?:LINT_KERNEL_FILE))");
-    if (RegexSearch(RE_SEARCH_C_FILE, line, m_re_result_temp))
+    if (RegexSearch(RE_SEARCH_C_FILE, line))
         m_error_suppressions.AddDefaultCSuppressions();
-    if (RegexSearch(RE_SEARCH_KERNEL_FILE, line, m_re_result_temp))
+    if (RegexSearch(RE_SEARCH_KERNEL_FILE, line))
         m_error_suppressions.AddDefaultKernelSuppressions();
 }
 
@@ -300,10 +300,10 @@ std::string FileLinter::GetHeaderGuardCPPVariable() {
     // flymake.
     static const regex_code RE_PATTERN_FLYMAKE =
         RegexCompile(R"(_flymake\.h$)");
-    RegexReplace(RE_PATTERN_FLYMAKE, ".h", &new_filename, m_re_result_temp);
+    RegexReplace(RE_PATTERN_FLYMAKE, ".h", &new_filename);
     static const regex_code RE_PATTERN_FLYMAKE2 =
         RegexCompile(R"(/\.flymake/([^/]*)$)");
-    RegexReplace(RE_PATTERN_FLYMAKE2, R"(/\1)", &new_filename, m_re_result_temp);
+    RegexReplace(RE_PATTERN_FLYMAKE2, R"(/\1)", &new_filename);
 
     // Replace 'c++' with 'cpp'.
     new_filename = StrReplaceAll(new_filename, "C++", "cpp");
@@ -315,7 +315,7 @@ std::string FileLinter::GetHeaderGuardCPPVariable() {
     std::string root_str = file_path_from_root.string();
     static const regex_code RE_PATTERN_ALPHANUM =
         RegexCompile("[^a-zA-Z0-9]");
-    RegexReplace(RE_PATTERN_ALPHANUM, "_", &root_str, m_re_result_temp);
+    RegexReplace(RE_PATTERN_ALPHANUM, "_", &root_str);
     cppvar = StrToUpper(root_str) + "_";
     return cppvar;
 }
@@ -331,7 +331,7 @@ void FileLinter::CheckForHeaderGuard(const CleansedLines& clean_lines) {
     static const regex_code RE_PATTERN_NOLINT_HEADER =
         RegexCompile(R"(//\s*NOLINT\(build/header_guard\))");
     for (const std::string& line : raw_lines) {
-        if (RegexSearch(RE_PATTERN_NOLINT_HEADER, line, m_re_result_temp))
+        if (RegexSearch(RE_PATTERN_NOLINT_HEADER, line))
             return;
     }
 
@@ -339,7 +339,7 @@ void FileLinter::CheckForHeaderGuard(const CleansedLines& clean_lines) {
     static const regex_code RE_PATTERN_PRAGMA_ONCE =
         RegexCompile(R"(^\s*#pragma\s+once)");
     for (const std::string& line : raw_lines) {
-        if (RegexSearch(RE_PATTERN_PRAGMA_ONCE, line, m_re_result_temp))
+        if (RegexSearch(RE_PATTERN_PRAGMA_ONCE, line))
             return;
     }
 
@@ -408,7 +408,7 @@ void FileLinter::CheckForHeaderGuard(const CleansedLines& clean_lines) {
     bool no_single_line_comments = true;
     for (size_t i = 1; i < raw_lines.size() - 1; i++) {
         const std::string& line = raw_lines[i];
-        if (RegexMatch(RE_PATTERN_MULTILINE_COMMENT, line, m_re_result_temp)) {
+        if (RegexMatch(RE_PATTERN_MULTILINE_COMMENT, line)) {
             no_single_line_comments = false;
             break;
         }
@@ -437,7 +437,7 @@ bool FileLinter::IsForwardClassDeclaration(const std::string& elided_line) {
         return false;
     static const regex_code RE_PATTERN_CLASS_DECL =
         RegexCompile(R"(^\s*(\btemplate\b)*.*class\s+\w+;\s*$)");
-    return RegexMatch(RE_PATTERN_CLASS_DECL, elided_line, m_re_result_temp);
+    return RegexMatch(RE_PATTERN_CLASS_DECL, elided_line);
 }
 
 bool FileLinter::IsMacroDefinition(const CleansedLines& clean_lines,
@@ -486,7 +486,7 @@ void FileLinter::CheckForFunctionLengths(const CleansedLines& clean_lines, size_
         // ignore it, unless it's TEST or TEST_F.
         std::string function_name = StrSplit(GetMatchStr(m_re_result, line, 1)).back();
         if (function_name == "TEST" || function_name == "TEST_F" ||
-                !RegexMatch("[A-Z_]+$", function_name, m_re_result_temp))
+                !RegexMatch("[A-Z_]+$", function_name))
             starting_func = true;
     }
 
@@ -527,7 +527,7 @@ void FileLinter::CheckForFunctionLengths(const CleansedLines& clean_lines, size_
             Error(linenum, "readability/fn_size", 5,
                   "Lint failed to find start of function body.");
         }
-    } else if (RegexMatch(RE_PATTERN_FUNC_END, line, m_re_result_temp)) {  // function end
+    } else if (RegexMatch(RE_PATTERN_FUNC_END, line)) {  // function end
         function_state->Check(this, linenum, m_cpplint_state->VerboseLevel());
         function_state->End();
     } else if (!StrIsBlank(line)) {
@@ -607,7 +607,7 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
 
     static const regex_code RE_PATTERN_OPEN_BRACE =
         RegexCompile(R"(\s*{\s*$)");
-    if (RegexMatch(RE_PATTERN_OPEN_BRACE, line, m_re_result_temp)) {
+    if (RegexMatch(RE_PATTERN_OPEN_BRACE, line)) {
         // We allow an open brace to start a line in the case where someone is using
         // braces in a block to explicitly create a new scope, which is commonly used
         // to control the lifetime of stack-allocated variables.  Braces are also
@@ -618,7 +618,7 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
         // following line if it is part of an array initialization and would not fit
         // within the 80 character limit of the preceding line.
         const std::string& prevline = GetPreviousNonBlankLine(clean_lines, linenum);
-        if (!RegexSearch(R"([,;:}{(]\s*$)", prevline, m_re_result_temp) &&
+        if (!RegexSearch(R"([,;:}{(]\s*$)", prevline) &&
             GetFirstNonSpace(prevline) != '#' &&
             !(GetLineWidth(prevline) > m_options.LineLength() - 2 && StrContain(prevline, "[]"))) {
             Error(linenum, "whitespace/braces", 4,
@@ -632,7 +632,7 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
     bool last_wrong = RegexMatch(RE_PATTERN_ELSE_AFTER_BRACE, line, m_re_result);
     if (last_wrong) {
         const std::string& prevline = GetPreviousNonBlankLine(clean_lines, linenum);
-        if (RegexMatch(R"(\s*}\s*$)", prevline, m_re_result_temp)) {
+        if (RegexMatch(R"(\s*}\s*$)", prevline)) {
             Error(linenum, "whitespace/newline", 4,
                   "An else should appear on the same line as the preceding }");
         } else {
@@ -648,8 +648,8 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
         RegexCompile(R"(}\s*else[^{]*$)");
     static const regex_code RE_PATTERN_ELSE_BRACE_R =
         RegexCompile(R"([^}]*else\s*{)");
-    if (RegexSearch(RE_PATTERN_ELSE_IF, line, m_re_result_temp)) {       // could be multi-line if
-        bool brace_on_left = RegexSearch(R"(}\s*else if\s*\()", line, m_re_result_temp);
+    if (RegexSearch(RE_PATTERN_ELSE_IF, line)) {       // could be multi-line if
+        bool brace_on_left = RegexSearch(R"(}\s*else if\s*\()", line);
         // find the ( after the if
         size_t pos = line.find("else if");
         pos = line.find('(', pos);
@@ -658,7 +658,7 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
             size_t endpos = pos;
             const std::string& endline = CloseExpression(clean_lines, &endlinenum, &endpos);
             bool brace_on_right = endpos != INDEX_NONE &&
-                                  endline.substr(endpos).find('{') != std::string::npos;
+                                  endline.find('{', endpos) != std::string::npos;
             if (brace_on_left != brace_on_right) {    // must be brace after if
                 Error(linenum, "readability/braces", 5,
                       "If an else has a brace on one side, it should have it on both");
@@ -666,10 +666,8 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
         }
 
     // Prevent detection if statement has { and we detected an improper newline after }
-    } else if (RegexSearch(RE_PATTERN_ELSE_BRACE_L, line,
-                           m_re_result_temp) ||
-               (RegexMatch(RE_PATTERN_ELSE_BRACE_R, line,
-                           m_re_result_temp) && !last_wrong)) {
+    } else if (RegexSearch(RE_PATTERN_ELSE_BRACE_L, line) ||
+               (RegexMatch(RE_PATTERN_ELSE_BRACE_R, line) && !last_wrong)) {
         Error(linenum, "readability/braces", 5,
               "If an else has a brace on one side, it should have it on both");
     }
@@ -739,13 +737,13 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
         // line. If found, this isn't a single-statement conditional.
         static const regex_code RE_PATTERN_IF_OPEN_BRACE =
             RegexCompile(R"(\s*(?:\[\[(?:un)?likely\]\]\s*)?{)");
-        if (!RegexMatch(RE_PATTERN_IF_OPEN_BRACE, endline_sub, m_re_result_temp) &&
+        if (!RegexMatch(RE_PATTERN_IF_OPEN_BRACE, endline_sub) &&
             !(StrIsBlank(endline_sub) &&
               endlinenum < (clean_lines.NumLines() - 1) &&
               GetFirstNonSpace(clean_lines.GetElidedAt(endlinenum + 1)) == '{')) {
             while (endlinenum < clean_lines.NumLines() &&
                    !(endpos != INDEX_NONE &&
-                     StrContain(clean_lines.GetElidedAt(endlinenum).substr(endpos), ';'))) {
+                     StrContain(clean_lines.GetElidedAt(endlinenum), ';', endpos))) {
                 endlinenum += 1;
                 endpos = 0;
             }
@@ -754,11 +752,11 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
                 // We allow a mix of whitespace and closing braces (e.g. for one-liner
                 // methods) and a single \ after the semicolon (for macros)
                 endpos = endline.find(';');
-                if (!RegexMatch(R"(;[\s}]*(\\?)$)", endline.substr(endpos), m_re_result_temp)) {
+                if (!RegexMatchWithRange(R"(;[\s}]*(\\?)$)", endline, endpos, endline.size() - endpos)) {
                     // Semicolon isn't the last character, there's something trailing.
                     // Output a warning if the semicolon is not contained inside
                     // a lambda expression.
-                    if (!RegexMatch(R"(^[^{};]*\[[^\[\]]*\][^{}]*\{[^{}]*\}\s*\)*[;,]\s*$)", endline, m_re_result_temp)) {
+                    if (!RegexMatch(R"(^[^{};]*\[[^\[\]]*\][^{}]*\{[^{}]*\}\s*\)*[;,]\s*$)", endline)) {
                         Error(linenum, "readability/braces", 4,
                               "If/else bodies with multiple statements require braces");
                     }
@@ -769,7 +767,7 @@ void FileLinter::CheckBraces(const CleansedLines& clean_lines,
                     // With ambiguous nested if statements, this will error out on the
                     // if that *doesn't* match the else, regardless of whether it's the
                     // inner one or outer one.
-                    if (if_match && RegexMatch(R"(\s*else\b)", next_line, m_re_result_temp) &&
+                    if (if_match && RegexMatch(R"(\s*else\b)", next_line) &&
                         next_indent != if_indent) {
                         Error(linenum, "readability/braces", 4,
                               "Else clause should be indented at the same level as if. "
@@ -883,16 +881,16 @@ void FileLinter::CheckTrailingSemicolon(const CleansedLines& clean_lines,
                             "LOCKS_EXCLUDED", "INTERFACE_DEF"},
                             GetMatchStr(macro_m, line_prefix, 1))) ||
                     (func && !RegexSearch(R"(\boperator\s*\[\s*\])",
-                                GetMatchStr(func_m, line_prefix, 1), m_re_result_temp)) ||
-                    RegexSearch(R"(\b(?:struct|union)\s+alignas\s*$)", line_prefix, m_re_result_temp) ||
-                    RegexSearch(R"(\bdecltype$)", line_prefix, m_re_result_temp) ||
-                    RegexSearch(R"(\s+=\s*$)", line_prefix, m_re_result_temp)) {
+                                GetMatchStr(func_m, line_prefix, 1))) ||
+                    RegexSearch(R"(\b(?:struct|union)\s+alignas\s*$)", line_prefix) ||
+                    RegexSearch(R"(\bdecltype$)", line_prefix) ||
+                    RegexSearch(R"(\s+=\s*$)", line_prefix)) {
                 match = false;
             }
         }
         if (match &&
                 endlinenum > 1 &&
-                RegexSearch(R"(\]\s*$)", clean_lines.GetElidedAt(endlinenum - 1), m_re_result_temp)) {
+                RegexSearch(R"(\]\s*$)", clean_lines.GetElidedAt(endlinenum - 1))) {
             // Multi-line lambda-expression
             match = false;
         }
@@ -916,8 +914,7 @@ void FileLinter::CheckTrailingSemicolon(const CleansedLines& clean_lines,
                 RegexCompile(R"([;{}]\s*$)");
             static const regex_code RE_PATTERN_BLOCK_START =
                 RegexCompile(R"(^(\s*)\{)");
-            if (!prevline.empty() && RegexSearch(RE_PATTERN_TRAIL_SPACE, prevline,
-                                                 m_re_result_temp)) {
+            if (!prevline.empty() && RegexSearch(RE_PATTERN_TRAIL_SPACE, prevline)) {
                 match = RegexMatch(RE_PATTERN_BLOCK_START, line, m_re_result);
             }
         }
@@ -929,7 +926,7 @@ void FileLinter::CheckTrailingSemicolon(const CleansedLines& clean_lines,
         size_t endpos = GetMatchEnd(m_re_result, 1);
         const std::string& endline = CloseExpression(
                                         clean_lines, &endlinenum, &endpos);
-        if (endpos != INDEX_NONE && GetFirstNonSpace(endline.substr(endpos)) == ';') {
+        if (endpos != INDEX_NONE && GetFirstNonSpace(endline, endpos) == ';') {
             // Current {} pair is eligible for semicolon check, and we have found
             // the redundant semicolon, output warning here.
             //
@@ -985,7 +982,7 @@ void FileLinter::CheckEmptyBlockBody(const CleansedLines& clean_lines,
             std::string opening_line_fragment = end_line.substr(end_pos);
             // Loop until EOF or find anything that's not whitespace or opening {.
             while (GetFirstNonSpace(opening_line_fragment) != '{') {
-                if (RegexSearch(R"(^(?!\s*$))", opening_line_fragment, m_re_result_temp)) {
+                if (RegexSearch(R"(^(?!\s*$))", opening_line_fragment)) {
                     // Conditional has no brackets.
                     return;
                 }
@@ -1019,8 +1016,7 @@ void FileLinter::CheckEmptyBlockBody(const CleansedLines& clean_lines,
             // and the portion of the closing line before the }.
             bool dummy;
             if (clean_lines.GetRawLineAt(opening_linenum) !=
-                CleanseComments(clean_lines.GetRawLineAt(opening_linenum),
-                                &dummy, m_re_result_temp)) {
+                CleanseComments(clean_lines.GetRawLineAt(opening_linenum), &dummy)) {
                 // Opening line ends with a comment, so conditional isn't empty.
                 return;
             }
@@ -1048,8 +1044,8 @@ void FileLinter::CheckEmptyBlockBody(const CleansedLines& clean_lines,
             std::string current_line_fragment = closing_line.substr(closing_pos);
             // Loop until EOF or find anything that's not whitespace or else clause.
             while (RegexSearch(R"(^\s*$|^(?=\s*else))",
-                               current_line_fragment, m_re_result_temp)) {
-                if (RegexSearch(R"(^(?=\s*else))", current_line_fragment, m_re_result_temp)) {
+                               current_line_fragment)) {
+                if (RegexSearch(R"(^(?=\s*else))", current_line_fragment)) {
                     // Found an else clause, so don't log an error.
                     return;
                 }
@@ -1090,8 +1086,8 @@ void FileLinter::CheckComment(const std::string& line,
     // Allow one space for new scopes, two spaces otherwise:
     static const regex_code RE_PATTERN_SPACE_FOR_SCOPE =
         RegexCompile(R"(^.*{ *//)");
-    if (!(RegexMatch(RE_PATTERN_SPACE_FOR_SCOPE, line,
-                     m_re_result_temp) && next_line_start == commentpos) &&
+    if (!(RegexMatch(RE_PATTERN_SPACE_FOR_SCOPE, line)
+            && next_line_start == commentpos) &&
         ((commentpos >= 1 && !IS_SPACE(line[commentpos-1])) ||
          (commentpos >= 2 && !IS_SPACE(line[commentpos-2])))) {
         Error(linenum, "whitespace/comments", 2,
@@ -1099,10 +1095,10 @@ void FileLinter::CheckComment(const std::string& line,
     }
 
     // Checks for common mistakes in TODO comments.
-    std::string comment = line.substr(commentpos);
     static const regex_code RE_PATTERN_TODO =
         RegexCompile(R"(^//(\s*)TODO(\(.+?\))?:?(\s|$)?)");
-    bool match = RegexMatch(RE_PATTERN_TODO, comment, m_re_result);
+    bool match = RegexMatchWithRange(RE_PATTERN_TODO, line,
+                                     commentpos, line.size() - commentpos, m_re_result);
     if (match) {
         // One whitespace is correct; zero whitespace is handled elsewhere.
         size_t leading_whitespace_size = GetMatchSize(m_re_result, 1);
@@ -1118,7 +1114,7 @@ void FileLinter::CheckComment(const std::string& line,
                   "\"// TODO(my_username): Stuff.\"");
         }
 
-        std::string middle_whitespace = GetMatchStr(m_re_result, comment, 3);
+        std::string middle_whitespace = GetMatchStr(m_re_result, line, 3, commentpos);
         // Comparisons made explicit for correctness
         //  -- pylint: disable=g-explicit-bool-comparison
         if (!IsMatched(m_re_result, 3) ||
@@ -1134,8 +1130,9 @@ void FileLinter::CheckComment(const std::string& line,
     // it's a /// or //! Doxygen comment.
     static const regex_code RE_PATTERN_COMMENT_NOSPACE =
         RegexCompile(R"(//[^ ]*\w)");
-    if (RegexMatch(RE_PATTERN_COMMENT_NOSPACE, comment, m_re_result) &&
-        !RegexMatch(R"((///|//\!)(\s+|$))", comment, m_re_result)) {
+    if (RegexMatchWithRange(RE_PATTERN_COMMENT_NOSPACE, line,
+                            commentpos, line.size() - commentpos) &&
+        !RegexMatch(R"((///|//\!)(\s+|$))", line)) {
         Error(linenum, "whitespace/comments", 4,
               "Should have a space between // and comment");
     }
@@ -1177,7 +1174,7 @@ void FileLinter::CheckSpacing(const CleansedLines& clean_lines,
         //                This ignores whitespace at the start of a namespace block
         //                because those are not usually indented.
         if (prevbrace != std::string::npos &&
-            prev_line.substr(prevbrace).find('}') == std::string::npos) {
+            prev_line.find('}', prevbrace) == std::string::npos) {
             // OK, we have a blank line at the start of a code block.  Before we
             // complain, we check if it is an exception to the rule: The previous
             // non-empty line has the parameters of a function header that are indented
@@ -1186,13 +1183,12 @@ void FileLinter::CheckSpacing(const CleansedLines& clean_lines,
             // the previous line is indented 6 spaces, which may happen when the
             // initializers of a constructor do not fit into a 80 column line.
             bool exception = false;
-            if (RegexMatch(R"( {6}\w)", prev_line, m_re_result_temp)) {  // Initializer list?
+            if (RegexMatch(R"( {6}\w)", prev_line)) {  // Initializer list?
                 // We are looking for the opening column of initializer list, which
                 // should be indented 4 spaces to cause 6 space indentation afterwards.
                 size_t search_position = (linenum >= 2) ? linenum - 2 : INDEX_NONE;
                 while (search_position != INDEX_NONE &&
-                       RegexMatch(R"( {6}\w)", clean_lines.GetElidedAt(search_position),
-                                  m_re_result_temp)) {
+                       RegexMatch(R"( {6}\w)", clean_lines.GetElidedAt(search_position))) {
                     search_position--;
                 }
                 exception = (search_position != INDEX_NONE &&
@@ -1205,8 +1201,8 @@ void FileLinter::CheckSpacing(const CleansedLines& clean_lines,
                 // a function header.  If we have a colon indented 4 spaces, it is an
                 // initializer list.
                 exception = (RegexMatch(R"( {4}\w[^\(]*\)\s*(const\s*)?(\{\s*$|:))",
-                                           prev_line, m_re_result_temp) ||
-                             RegexMatch(R"( {4}:)", prev_line, m_re_result_temp));
+                                           prev_line) ||
+                             RegexMatch(R"( {4}:)", prev_line));
             }
 
             if (!exception) {
@@ -1260,8 +1256,8 @@ void FileLinter::CheckSpacing(const CleansedLines& clean_lines,
         RegexCompile(R"(\w\s+\[(?!\[))");
     static const regex_code RE_PATTERN_ATTRIBUTES =
         RegexCompile(R"((?:auto&?|delete|return)\s+\[)");
-    if (RegexSearch(RE_PATTERN_BRACKETS, elided, m_re_result_temp) &&
-        !RegexSearch(RE_PATTERN_ATTRIBUTES, elided, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_BRACKETS, elided) &&
+        !RegexSearch(RE_PATTERN_ATTRIBUTES, elided)) {
         Error(linenum, "whitespace/braces", 5,
               "Extra space before [");
     }
@@ -1272,8 +1268,8 @@ void FileLinter::CheckSpacing(const CleansedLines& clean_lines,
         RegexCompile(R"(for *\(.*[^:]:[^: ])");
     static const regex_code RE_PATTERN_FORCOLON2 =
         RegexCompile(R"(for *\(.*[^: ]:[^:])");
-    if (RegexSearch(RE_PATTERN_FORCOLON, elided, m_re_result_temp) ||
-        RegexSearch(RE_PATTERN_FORCOLON2, elided, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_FORCOLON, elided) ||
+        RegexSearch(RE_PATTERN_FORCOLON2, elided)) {
         Error(linenum, "whitespace/forcolon", 2,
               "Missing space around colon in range-based for loop");
     }
@@ -1451,7 +1447,7 @@ void FileLinter::CheckParenthesisSpacing(const std::string& elided_line, size_t 
         if (str2_size != GetMatchSize(m_re_result, 4)) {
             if (!((StrIsChar(GetMatchStr(m_re_result, line, 3), ';') &&
                 (str2_size == 1 + GetMatchSize(m_re_result, 4))) ||
-                (str2_size == 0 && RegexSearch(R"(\bfor\s*\(.*; \))", line, m_re_result_temp)))) {
+                (str2_size == 0 && RegexSearch(R"(\bfor\s*\(.*; \))", line)))) {
                 Error(linenum, "whitespace/parens", 5,
                       "Mismatching spaces inside () in " + GetMatchStr(m_re_result, line, 1));
             }
@@ -1490,16 +1486,13 @@ void FileLinter::CheckCommaSpacing(const CleansedLines& clean_lines,
     if (StrContain(line, "operator") || StrContain(line, "__VA_OPT__")) {
         match = RegexSearch(RE_PATTERN_COMMA_SPACING,
             RegexReplace(RE_PATTERN_VA_OPT, "",
-                RegexReplace(RE_PATTERN_OPERATOR, "F(", line, m_re_result_temp),
-                m_re_result_temp),
-            m_re_result_temp);
+                RegexReplace(RE_PATTERN_OPERATOR, "F(", line)));
     } else {
-        match = RegexSearch(RE_PATTERN_COMMA_SPACING, line, m_re_result_temp);
+        match = RegexSearch(RE_PATTERN_COMMA_SPACING, line);
     }
 
     if (match && RegexSearch(RE_PATTERN_COMMA_SPACING,
-                             clean_lines.GetLineWithoutRawStringAt(linenum),
-                             m_re_result_temp)) {
+                             clean_lines.GetLineWithoutRawStringAt(linenum))) {
         Error(linenum, "whitespace/comma", 3,
                               "Missing space after ,");
     }
@@ -1510,7 +1503,7 @@ void FileLinter::CheckCommaSpacing(const CleansedLines& clean_lines,
     // space after ;
     static const regex_code RE_PATTERN_SEMICOLON_SPACING =
         RegexCompile(R"(;[^\s};\\)/])");
-    if (RegexSearch(RE_PATTERN_SEMICOLON_SPACING, line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_SEMICOLON_SPACING, line)) {
         Error(linenum, "whitespace/semicolon", 3,
                               "Missing space after ;");
     }
@@ -1532,8 +1525,7 @@ const regex_code RE_PATTERN_TYPES =
 static bool IsType(const CleansedLines& clean_lines,
                    NestingState* nesting_state,
                    const std::string& expr,
-                   regex_match& re_result,
-                   regex_match& re_result_temp) {
+                   regex_match& re_result) {
     // Check if expression looks like a type name, returns true if so.
     // Keep only the last token in the expression
     bool match = RegexMatch(R"(^.*(\b\S+)$)", expr, re_result);
@@ -1544,7 +1536,7 @@ static bool IsType(const CleansedLines& clean_lines,
         token = expr;
 
     // Match native types and stdint types
-    if (RegexMatch(RE_PATTERN_TYPES, token, re_result_temp))
+    if (RegexMatch(RE_PATTERN_TYPES, token))
         return true;
 
     // Try a bit harder to match templated types.  Walk up the nesting
@@ -1584,7 +1576,7 @@ static bool IsType(const CleansedLines& clean_lines,
 
         // Look for typename in the specified range
         for (size_t i = first_line; i < last_line + 1; i++) {
-            if (RegexSearch(typename_pattern, clean_lines.GetElidedAt(i), re_result_temp))
+            if (RegexSearch(typename_pattern, clean_lines.GetElidedAt(i)))
                 return true;
         }
         block_index--;
@@ -1651,9 +1643,9 @@ void FileLinter::CheckBracesSpacing(const CleansedLines& clean_lines,
         // We also suppress warnings for `uint64_t{expression}` etc., as the style
         // guide recommends brace initialization for integral types to avoid
         // overflow/truncation.
-        if (!RegexMatch(R"(^[\s}]*[{.;,)<>\]:])", trailing_text, m_re_result_temp)
+        if (!RegexMatch(R"(^[\s}]*[{.;,)<>\]:])", trailing_text)
                 && !IsType(clean_lines, nesting_state, leading_text,
-                           m_re_result, m_re_result_temp)) {
+                           m_re_result)) {
             Error(linenum, "whitespace/braces", 5,
                   "Missing space before {");
         }
@@ -1676,15 +1668,15 @@ void FileLinter::CheckBracesSpacing(const CleansedLines& clean_lines,
         RegexCompile(R"(\s+;\s*$)");
     static const regex_code RE_PATTERN_SEMICOLON_FOR =
         RegexCompile(R"(\bfor\b)");
-    if (RegexSearch(RE_PATTERN_SEMICOLON_EMPTY, line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_SEMICOLON_EMPTY, line)) {
         Error(linenum, "whitespace/semicolon", 5,
               "Semicolon defining empty statement. Use {} instead.");
-    } else if (RegexSearch(RE_PATTERN_SEMICOLON_ONLY, line, m_re_result_temp)) {
+    } else if (RegexSearch(RE_PATTERN_SEMICOLON_ONLY, line)) {
         Error(linenum, "whitespace/semicolon", 5,
               "Line contains only semicolon. If this should be an empty statement, "
               "use {} instead.");
-    } else if (RegexSearch(RE_PATTERN_SEMICOLON_EXTRA, line, m_re_result_temp) &&
-               !RegexSearch(RE_PATTERN_SEMICOLON_FOR, line, m_re_result_temp)) {
+    } else if (RegexSearch(RE_PATTERN_SEMICOLON_EXTRA, line) &&
+               !RegexSearch(RE_PATTERN_SEMICOLON_FOR, line)) {
         Error(linenum, "whitespace/semicolon", 5,
               "Extra space before last semicolon. If this should be an empty "
               "statement, use {} instead.");
@@ -1743,21 +1735,21 @@ void FileLinter::CheckSpacingForFunctionCallBase(const std::string& line,
     static const regex_code RE_PATTERN_ARRAY_REF =
         RegexCompile(R"( \([^)]+\)\[[^\]]+\])");
     if (  // Ignore control structures.
-          RegexSearch(RE_PATTERN_CTRL_STRUCT, fncall, m_re_result_temp) ||
+          RegexSearch(RE_PATTERN_CTRL_STRUCT, fncall) ||
           // Ignore pointers/references to functions.
-          RegexSearch(RE_PATTERN_FUNC_REF, fncall, m_re_result_temp) ||
+          RegexSearch(RE_PATTERN_FUNC_REF, fncall) ||
           // Ignore pointers/references to arrays.
-          RegexSearch(RE_PATTERN_ARRAY_REF, fncall, m_re_result_temp))
+          RegexSearch(RE_PATTERN_ARRAY_REF, fncall))
         return;
 
     static const regex_code RE_PATTERN_FUNC_PARENS =
         RegexCompile(R"(\w\s*\(\s(?!\s*\\$))");
     static const regex_code RE_PATTERN_PARENS =
         RegexCompile(R"(\(\s+(?!(\s*\\)|\())");
-    if (RegexSearch(RE_PATTERN_FUNC_PARENS, fncall, m_re_result_temp)) {  // a ( used for a fn call
+    if (RegexSearch(RE_PATTERN_FUNC_PARENS, fncall)) {  // a ( used for a fn call
         Error(linenum, "whitespace/parens", 4,
               "Extra space after ( in function call");
-    } else if (RegexSearch(RE_PATTERN_PARENS, fncall, m_re_result_temp)) {
+    } else if (RegexSearch(RE_PATTERN_PARENS, fncall)) {
         Error(linenum, "whitespace/parens", 2,
               "Extra space after (");
     }
@@ -1772,14 +1764,14 @@ void FileLinter::CheckSpacingForFunctionCallBase(const std::string& line,
         RegexCompile(R"(\w\s+\((\w+::)*\*\w+\)\()");
     static const regex_code RE_PATTERN_CASE =
         RegexCompile(R"(\bcase\s+\()");
-    if (RegexSearch(RE_PATTERN_SPACE_BEFORE_PARENS, fncall, m_re_result_temp) &&
-        !RegexSearch(RE_PATTERN_ASM, fncall, m_re_result_temp) &&
-        !RegexSearch(RE_PATTERN_MACRO, fncall, m_re_result_temp) &&
-        !RegexSearch(RE_PATTERN_COLON, fncall, m_re_result_temp) &&
-        !RegexSearch(RE_PATTERN_CASE, fncall, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_SPACE_BEFORE_PARENS, fncall) &&
+        !RegexSearch(RE_PATTERN_ASM, fncall) &&
+        !RegexSearch(RE_PATTERN_MACRO, fncall) &&
+        !RegexSearch(RE_PATTERN_COLON, fncall) &&
+        !RegexSearch(RE_PATTERN_CASE, fncall)) {
         // TODO(unknown): Space after an operator function seem to be a common
         // error, silence those for now by restricting them to highest verbosity.
-        if (RegexSearch(R"(\boperator_*\b)", line, m_re_result_temp)) {
+        if (RegexSearch(R"(\boperator_*\b)", line)) {
             Error(linenum, "whitespace/parens", 0,
                   "Extra space before ( in function call");
         } else {
@@ -1792,14 +1784,14 @@ void FileLinter::CheckSpacingForFunctionCallBase(const std::string& line,
     // part of a control statement (if/while/etc), and don't complain
     static const regex_code RE_PATTERN_EOL_BRACE =
         RegexJitCompile(R"([^)]\s+\)\s*[^{\s])");
-    if (!RegexSearch(RE_PATTERN_EOL_BRACE, fncall, m_re_result_temp))
+    if (!RegexSearch(RE_PATTERN_EOL_BRACE, fncall))
         return;
 
     // If the closing parenthesis is preceded by only whitespaces,
     // try to give a more descriptive error message.
     static const regex_code RE_PATTERN_CLOSE_PARENS =
         RegexCompile(R"(^\s+\))");
-    if (RegexSearch(RE_PATTERN_CLOSE_PARENS, fncall, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_CLOSE_PARENS, fncall)) {
         Error(linenum, "whitespace/parens", 2,
                               "Closing ) should be moved to the previous line");
     } else {
@@ -1888,7 +1880,7 @@ void FileLinter::CheckCheck(const CleansedLines& clean_lines,
     // If the check macro is followed by something other than a
     // semicolon, assume users will log their own custom error messages
     // and don't suggest any replacements.
-    if (GetFirstNonSpace(last_line.substr(end_pos)) != ';')
+    if (GetFirstNonSpace(last_line, end_pos) != ';')
         return;
 
     std::string expression = "";
@@ -1978,8 +1970,8 @@ void FileLinter::CheckCheck(const CleansedLines& clean_lines,
     rhs = StrStrip(rhs);
     static const regex_code RE_PATTERN_MATCH_CONSTANT =
         RegexCompile(R"(^([-+]?(\d+|0[xX][0-9a-fA-F]+)[lLuU]{0,3}|".*"|\'.*\')$)");
-    if (RegexMatch(RE_PATTERN_MATCH_CONSTANT, lhs, m_re_result_temp) ||
-        RegexMatch(RE_PATTERN_MATCH_CONSTANT, rhs, m_re_result_temp)) {
+    if (RegexMatch(RE_PATTERN_MATCH_CONSTANT, lhs) ||
+        RegexMatch(RE_PATTERN_MATCH_CONSTANT, rhs)) {
         // Note: since we know both lhs and rhs, we can provide a more
         // descriptive error message like:
         //   Consider using CHECK_EQ(x, 42) instead of CHECK(x == 42)
@@ -2071,15 +2063,15 @@ void FileLinter::CheckSectionSpacing(const CleansedLines& clean_lines,
     // common when defining classes in C macros.
     const std::string& prev_line = clean_lines.GetLineAt(linenum - 1);
     if (!StrIsBlank(prev_line) &&
-        !RegexSearch(R"(\b(class|struct)\b)", prev_line, m_re_result_temp) &&
-        !RegexSearch(R"(\\$)", prev_line, m_re_result_temp)) {
+        !RegexSearch(R"(\b(class|struct)\b)", prev_line) &&
+        !RegexSearch(R"(\\$)", prev_line)) {
         // Try a bit harder to find the beginning of the class.  This is to
         // account for multi-line base-specifier lists, e.g.:
         //   class Derived
         //       : public Base {
         size_t end_class_head = classinfo->StartingLinenum();
         for (size_t i = end_class_head; i < linenum; i++) {
-            if (RegexSearch(R"(\{\s*$)", clean_lines.GetLineAt(i), m_re_result_temp)) {
+            if (RegexSearch(R"(\{\s*$)", clean_lines.GetLineAt(i))) {
                 end_class_head = i;
                 break;
             }
@@ -2133,12 +2125,11 @@ void FileLinter::CheckStyle(const CleansedLines& clean_lines,
         RegexCompile(R"(\s*(?:public|private|protected|signals)(?:\s+(?:slots\s*)?)?:\s*\\?$)");
     if (!(linenum > 0 &&
           RegexSearch(RE_PATTERN_SPACES,
-                      clean_lines.GetLineWithoutRawStringAt(linenum - 1),
-                      m_re_result_temp)) &&
+                      clean_lines.GetLineWithoutRawStringAt(linenum - 1))) &&
         (initial_spaces == 1 || initial_spaces == 3) &&
-        !RegexMatch(RE_PATTERN_SCOPE_OR_LABEL, cleansed_line, m_re_result_temp) &&
+        !RegexMatch(RE_PATTERN_SCOPE_OR_LABEL, cleansed_line) &&
         !(clean_lines.GetRawLineAt(linenum) != line &&
-          RegexMatch(R"(^\s*"")", line, m_re_result_temp))) {
+          RegexMatch(R"(^\s*"")", line))) {
         Error(linenum, "whitespace/indent", 3,
               "Weird number of spaces at line-start.  "
               "Are you using a 2-space indent?");
@@ -2179,10 +2170,10 @@ void FileLinter::CheckStyle(const CleansedLines& clean_lines,
     static const regex_code RE_PATTERN_DOC =
         RegexCompile(R"(^\s*/// [@\\](copydoc|copydetails|copybrief) .*$)");
     if (!line.starts_with("#include") && !is_header_guard &&
-        !RegexMatch(RE_PATTERN_URL, line, m_re_result_temp) &&
-        !RegexMatch(RE_PATTERN_COMMENT, line, m_re_result_temp) &&
-        !RegexMatch(RE_PATTERN_ID, line, m_re_result_temp) &&
-        !RegexMatch(RE_PATTERN_DOC, line, m_re_result_temp)) {
+        !RegexMatch(RE_PATTERN_URL, line) &&
+        !RegexMatch(RE_PATTERN_COMMENT, line) &&
+        !RegexMatch(RE_PATTERN_ID, line) &&
+        !RegexMatch(RE_PATTERN_DOC, line)) {
         size_t line_width = GetLineWidth(line);
         size_t line_length = m_options.LineLength();
         if (line_width > line_length) {
@@ -2196,7 +2187,7 @@ void FileLinter::CheckStyle(const CleansedLines& clean_lines,
 
     if (StrCount(cleansed_line, ';') > 1 &&
             // allow simple single line lambdas
-            !RegexMatch(RE_PATTERN_LAMBDA, line, m_re_result_temp) &&
+            !RegexMatch(RE_PATTERN_LAMBDA, line) &&
             // for loops are allowed two ;'s (and may run over two lines).
             !StrContain(cleansed_line, "for")) {
         const std::string& prev_line = GetPreviousNonBlankLine(clean_lines, linenum);
@@ -2275,7 +2266,7 @@ int FileLinter::ClassifyInclude(const fs::path& path_from_repo,
     bool is_std_c_header = (include_order == INCLUDE_ORDER_DEFAULT) ||
                             (InStrVec(C_HEADERS, include_str) ||
                             // additional linux glibc header folders
-                            RegexSearch(GetHeaderFoldersPattern(), include_str, m_re_result_temp));
+                            RegexSearch(GetHeaderFoldersPattern(), include_str));
 
     // Headers with C++ extensions shouldn't be considered C system headers
     std::string include_ext = include.extension().string();
@@ -2344,7 +2335,7 @@ void FileLinter::CheckIncludeLine(const CleansedLines& clean_lines, size_t linen
     if (match) {
         if (m_options.IsHeaderExtension(GetMatchStr(m_re_result, line, 2)) &&
             !RegexMatch(RE_PATTERN_INCLUDE_EXT,
-                        GetMatchStr(m_re_result, line, 1), m_re_result_temp)) {
+                        GetMatchStr(m_re_result, line, 1))) {
             Error(linenum, "build/include_subdir", 4,
                   "Include the directory when naming header files");
         }
@@ -2391,7 +2382,7 @@ void FileLinter::CheckIncludeLine(const CleansedLines& clean_lines, size_t linen
             }
         }
 
-        if (third_src_header || !RegexMatch(RE_PATTERN_INCLUDE_EXT, include, m_re_result_temp)) {
+        if (third_src_header || !RegexMatch(RE_PATTERN_INCLUDE_EXT, include)) {
             include_state->LastIncludeList().emplace_back(include, linenum);
 
             // We want to ensure that headers appear in the right order:
@@ -2435,14 +2426,14 @@ bool FileLinter::ExpectingFunctionArgs(const CleansedLines& clean_lines,
         RegexCompile(R"(^\s*MOCK_(?:CONST_)?METHOD\d+(?:_T)?\(\s*$)");
     static const regex_code RE_PATTERN_STD_M =
         RegexCompile(R"(\bstd::m?function\s*\<\s*$)");
-    return (RegexMatch(RE_PATTERN_MOCK, elided_line, m_re_result_temp) ||
+    return (RegexMatch(RE_PATTERN_MOCK, elided_line) ||
             (linenum >= 2 &&
              (RegexMatch(RE_PATTERN_MOCK2,
-                         clean_lines.GetElidedAt(linenum - 1), m_re_result_temp) ||
+                         clean_lines.GetElidedAt(linenum - 1)) ||
               RegexMatch(RE_PATTERN_MOCK3,
-                         clean_lines.GetElidedAt(linenum - 2), m_re_result_temp) ||
+                         clean_lines.GetElidedAt(linenum - 2)) ||
               RegexSearch(RE_PATTERN_STD_M,
-                          clean_lines.GetElidedAt(linenum - 1), m_re_result_temp))));
+                          clean_lines.GetElidedAt(linenum - 1)))));
 }
 
 bool FileLinter::CheckCStyleCast(const CleansedLines& clean_lines,
@@ -2458,7 +2449,7 @@ bool FileLinter::CheckCStyleCast(const CleansedLines& clean_lines,
     size_t pos = GetMatchStart(m_re_result, 1);
     std::string context = line.substr(0, (pos == 0) ? 0 : pos - 1);
     if (RegexMatch(R"(.*\b(?:sizeof|alignof|alignas|[_A-Z][_A-Z0-9]*)\s*$)",
-                   context, m_re_result_temp))
+                   context))
         return false;
 
     // Try expanding current context to see if we one level of
@@ -2469,7 +2460,7 @@ bool FileLinter::CheckCStyleCast(const CleansedLines& clean_lines,
             context = clean_lines.GetElidedAt(i) + context;
     }
     if (RegexMatch(R"(.*\b[_A-Z][_A-Z0-9]*\s*\((?:\([^()]*\)|[^()])*$)",
-                   context, m_re_result_temp))
+                   context))
         return false;
 
     // operator++(int) and operator--(int)
@@ -2479,9 +2470,10 @@ bool FileLinter::CheckCStyleCast(const CleansedLines& clean_lines,
 
     // A single unnamed argument for a function tends to look like old style cast.
     // If we see those, don't issue warnings for deprecated casts.
-    std::string remainder = line.substr(GetMatchEnd(m_re_result, 0));
-    if (RegexMatch(R"(^\s*(?:;|const\b|throw\b|final\b|override\b|[=>{),]|->))",
-                   remainder, m_re_result_temp))
+    size_t endpos = GetMatchEnd(m_re_result, 0);
+    if (RegexMatchWithRange(
+            R"(^\s*(?:;|const\b|throw\b|final\b|override\b|[=>{),]|->))",
+            line, endpos, line.size() - endpos))
         return false;
 
     // At this point, all that should be left is actual casts.
@@ -2526,7 +2518,7 @@ void FileLinter::CheckCasts(const CleansedLines& clean_lines,
         // Avoid arrays by looking for brackets that come after the closing
         // parenthesis.
         if (RegexMatch(R"(\([^()]+\)\s*\[)",
-                       GetMatchStr(m_re_result, line, 3), m_re_result_temp))
+                       GetMatchStr(m_re_result, line, 3)))
             return;
 
         // Other things to ignore:
@@ -2588,7 +2580,7 @@ void FileLinter::CheckCasts(const CleansedLines& clean_lines,
     static const regex_code RE_PATTERN_CAST_TYPE =
         RegexJitCompile(R"((?:[^\w]&\(([^)*][^)]*)\)[\w(])|)"
                         R"((?:[^\w]&(static|dynamic|down|reinterpret)_cast\b))");
-    match = RegexSearch(RE_PATTERN_CAST_TYPE, line, m_re_result_temp);
+    match = RegexSearch(RE_PATTERN_CAST_TYPE, line);
     if (match) {
         // Try a better error message when the & is bound to something
         // dereferenced by the casted pointer, as opposed to the casted
@@ -2609,7 +2601,7 @@ void FileLinter::CheckCasts(const CleansedLines& clean_lines,
                     std::string extended_line = clean_lines.GetElidedAt(y2).substr(x2);
                     if (y2 < clean_lines.NumLines() - 1)
                         extended_line += clean_lines.GetElidedAt(y2 + 1);
-                    if (RegexMatch(R"(\s*(?:->|\[))", extended_line, m_re_result_temp))
+                    if (RegexMatch(R"(\s*(?:->|\[))", extended_line))
                         parenthesis_error = true;
                 }
             }
@@ -2661,11 +2653,11 @@ void FileLinter::CheckGlobalStatic(const std::string& elided_line, size_t linenu
     //    string Class::operator*()
     if (match &&
         !RegexSearch(R"(\bstring\b(\s+const)?\s*[\*\&]\s*(const\s+)?\w)",
-                     line, m_re_result_temp) &&
-        !RegexSearch(R"(\boperator\W)", line, m_re_result_temp) &&
+                     line) &&
+        !RegexSearch(R"(\boperator\W)", line) &&
         !RegexMatch(R"(\s*(<.*>)?(::[a-zA-Z0-9_]+)*\s*\(([^"]|$))",
-                    GetMatchStr(m_re_result, line, 4), m_re_result_temp)) {
-        if (RegexSearch(R"(\bconst\b)", line, m_re_result_temp)) {
+                    GetMatchStr(m_re_result, line, 4))) {
+        if (RegexSearch(R"(\bconst\b)", line)) {
             Error(linenum, "runtime/string", 4,
                   "For a static/global string constant, use a C style string instead:"
                   " \"" + GetMatchStr(m_re_result, line, 1) + "char" +
@@ -2681,8 +2673,8 @@ void FileLinter::CheckGlobalStatic(const std::string& elided_line, size_t linenu
         RegexJitCompile(R"(\b([A-Za-z0-9_]*_)\(\1\))");
     static const regex_code RE_PATTERN_INIT_WITH_ITSELF2 =
         RegexJitCompile(R"(\b([A-Za-z0-9_]*_)\(CHECK_NOTNULL\(\1\)\))");
-    if (RegexSearch(RE_PATTERN_INIT_WITH_ITSELF, line, m_re_result_temp) ||
-        RegexSearch(RE_PATTERN_INIT_WITH_ITSELF2, line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_INIT_WITH_ITSELF, line) ||
+        RegexSearch(RE_PATTERN_INIT_WITH_ITSELF2, line)) {
         Error(linenum, "runtime/init", 4,
               "You seem to be initializing a member variable with itself.");
     }
@@ -2711,7 +2703,7 @@ void FileLinter::CheckPrintf(const std::string& elided_line, size_t linenum) {
         // Check if some verboten C functions are being used.
         static const regex_code RE_PATTERN_SPRINTF =
             RegexCompile(R"(\bsprintf\s*\()");
-        if (RegexSearch(RE_PATTERN_SPRINTF, line, m_re_result_temp)) {
+        if (RegexSearch(RE_PATTERN_SPRINTF, line)) {
             Error(linenum, "runtime/printf", 5,
                 "Never use sprintf. Use snprintf instead.");
         }
@@ -2801,7 +2793,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
     if (line.empty())
         return;
 
-    bool match = RegexSearch(RE_PATTERN_INCLUDE, line, m_re_result_temp);
+    bool match = RegexSearch(RE_PATTERN_INCLUDE, line);
     if (match) {
         CheckIncludeLine(clean_lines, linenum, include_state);
         return;
@@ -2822,7 +2814,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
     static const regex_code RE_PATTERN_MULTILINE_TOKEN =
         RegexCompile("[;({]");
     if (linenum + 1 < clean_lines.NumLines() &&
-            !RegexSearch(RE_PATTERN_MULTILINE_TOKEN, line, m_re_result_temp)) {
+            !RegexSearch(RE_PATTERN_MULTILINE_TOKEN, line)) {
         // Match two lines at a time to support multiline declarations
         std::string new_line = line + StrStrip(clean_lines.GetElidedAt(linenum + 1));
         CheckGlobalStatic(new_line, linenum);
@@ -2843,8 +2835,8 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
     // we regularly allow is "unsigned short port" for port.
     static const regex_code RE_PATTERN_SHORT_PORT =
         RegexCompile(R"(\bshort port\b)");
-    if (RegexSearch(RE_PATTERN_SHORT_PORT, line, m_re_result_temp)) {
-        if (!RegexSearch(R"(\bunsigned short port\b)", line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_SHORT_PORT, line)) {
+        if (!RegexSearch(R"(\bunsigned short port\b)", line)) {
             Error(linenum, "runtime/int", 4,
                   "Use \"unsigned short\" for ports, not \"short\"");
         }
@@ -2867,7 +2859,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
     //   class Y { int operator&(const Y& x) { return 23; } }; // binary operator&
     static const regex_code RE_PATTERN_UNARY_OP =
         RegexCompile(R"(\boperator\s*&\s*\(\s*\))");
-    if (RegexSearch(RE_PATTERN_UNARY_OP, line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_UNARY_OP, line)) {
         Error(linenum, "runtime/operator", 4,
               "Unary operator& is dangerous.  Do not use it.");
     }
@@ -2876,7 +2868,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
     // } if (a == b) {
     static const regex_code RE_PATTERN_IF_AFTER_BRACE =
         RegexCompile(R"(\}\s*if\s*\()");
-    if (RegexSearch(RE_PATTERN_IF_AFTER_BRACE, line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_IF_AFTER_BRACE, line)) {
         Error(linenum, "readability/braces", 4,
               "Did you mean \"else if\"? If not, start a new line for \"if\".");
     }
@@ -2910,7 +2902,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
         RegexCompile(R"(memset\s*\(([^,]*),\s*([^,]*),\s*0\s*\))");
     match = RegexSearch(RE_PATTERN_MEMSET, line, m_re_result);
     if (match && !RegexMatch(R"(^''|-?[0-9]+|0x[0-9A-Fa-f]$)",
-                             GetMatchStr(m_re_result, line, 2), m_re_result_temp)) {
+                             GetMatchStr(m_re_result, line, 2))) {
         Error(linenum, "runtime/memset", 4,
               "Did you mean \"memset(" + GetMatchStr(m_re_result, line, 1) +
               ", 0, " + GetMatchStr(m_re_result, line, 2) + ")\"?");
@@ -2918,8 +2910,8 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
 
     static const regex_code RE_PATTERN_NAMESPACE_USING =
         RegexCompile(R"(\busing namespace\b)");
-    if (RegexSearch(RE_PATTERN_NAMESPACE_USING, line, m_re_result_temp)) {
-        if (RegexSearch(R"(\bliterals\b)", line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_NAMESPACE_USING, line)) {
+        if (RegexSearch(R"(\bliterals\b)", line)) {
             Error(linenum, "build/namespaces_literals", 5,
                   "Do not use namespace using-directives.  "
                   "Use using-declarations instead.");
@@ -2953,19 +2945,19 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
                     continue;
                 }
 
-                if (RegexSearch(R"(sizeof\(.+\))", tok, m_re_result_temp))
+                if (RegexSearch(R"(sizeof\(.+\))", tok))
                     continue;
-                if (RegexSearch(R"(arraysize\(\w+\))", tok, m_re_result_temp))
+                if (RegexSearch(R"(arraysize\(\w+\))", tok))
                     continue;
 
                 std::string tok_clean = StrLstrip(tok, '(');
                 tok_clean = StrRstrip(tok_clean, ')');
                 if (tok_clean.empty()) continue;
-                if (RegexMatch(R"(\d+)", tok_clean, m_re_result_temp)) continue;
-                if (RegexMatch("0[xX][0-9a-fA-F]+", tok_clean, m_re_result_temp)) continue;
-                if (RegexMatch(R"(k[A-Z0-9]\w*)", tok_clean, m_re_result_temp)) continue;
-                if (RegexMatch(R"((.+::)?k[A-Z0-9]\w*)", tok_clean, m_re_result_temp)) continue;
-                if (RegexMatch("(.+::)?[A-Z][A-Z0-9_]*", tok_clean, m_re_result_temp)) continue;
+                if (RegexMatch(R"(\d+)", tok_clean)) continue;
+                if (RegexMatch("0[xX][0-9a-fA-F]+", tok_clean)) continue;
+                if (RegexMatch(R"(k[A-Z0-9]\w*)", tok_clean)) continue;
+                if (RegexMatch(R"((.+::)?k[A-Z0-9]\w*)", tok_clean)) continue;
+                if (RegexMatch("(.+::)?[A-Z][A-Z0-9_]*", tok_clean)) continue;
                 // A catch all for tricky sizeof cases, including 'sizeof expression',
                 // 'sizeof(*type)', 'sizeof(const type)', 'sizeof(struct StructName)'
                 // requires skipping the next token because we split on ' ' and '*'.
@@ -2990,7 +2982,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
     static const regex_code RE_PATTERN_NAMESPACE_HEAD =
         RegexCompile(R"(\bnamespace\s*{)");
     if (is_header_extension &&
-        RegexSearch(RE_PATTERN_NAMESPACE_HEAD, line, m_re_result_temp) &&
+        RegexSearch(RE_PATTERN_NAMESPACE_HEAD, line) &&
         line.back() != '\\') {
         Error(linenum, "build/namespaces_headers", 4,
               "Do not use unnamed namespaces in header files.  See "
@@ -3019,7 +3011,9 @@ static bool IsDerivedFunction(const CleansedLines& clean_lines, size_t linenum,
             const std::string& close_line = CloseExpression(
                                         clean_lines, &pos, &closing_paren);
             return (closing_paren != INDEX_NONE &&
-                    RegexSearch(RE_PATTERN_OVERRIDE, close_line.substr(closing_paren), re_result));
+                    RegexSearchWithRange(RE_PATTERN_OVERRIDE,
+                                         close_line, closing_paren,
+                                         close_line.size() - closing_paren));
         }
         if (i == min_line) break;
     }
@@ -3027,16 +3021,15 @@ static bool IsDerivedFunction(const CleansedLines& clean_lines, size_t linenum,
 }
 
 // Check if current line contains an out-of-line method definition.
-static bool IsOutOfLineMethodDefinition(const CleansedLines& clean_lines, size_t linenum,
-                                        regex_match& re_result_temp) {
+static bool IsOutOfLineMethodDefinition(const CleansedLines& clean_lines, size_t linenum) {
     // Scan back a few lines for start of current function
     size_t min_line = (linenum >= 10) ? linenum - 10 : 0;
     for (size_t i = linenum;; i--) {
         const std::string& line = clean_lines.GetElidedAt(i);
-        if (RegexMatch(RE_PATTERN_FUNC_START, line, re_result_temp)) {
+        if (RegexMatch(RE_PATTERN_FUNC_START, line)) {
             static const regex_code RE_PATTERN_OUT_OF_LINE =
                 RegexCompile(R"(^[^()]*\w+::\w+\()");
-            return RegexMatch(RE_PATTERN_OUT_OF_LINE, line, re_result_temp);
+            return RegexMatch(RE_PATTERN_OUT_OF_LINE, line);
         }
         if (i == min_line) break;
     }
@@ -3141,7 +3134,7 @@ void FileLinter::CheckForNonConstReference(const CleansedLines& clean_lines,
 
     // Don't warn on out-of-line method definitions, as we would warn on the
     // in-line declaration, if it isn't marked with 'override'.
-    if (IsOutOfLineMethodDefinition(clean_lines, linenum, m_re_result_temp))
+    if (IsOutOfLineMethodDefinition(clean_lines, linenum))
         return;
 
     std::string line = elided_line;
@@ -3168,12 +3161,12 @@ void FileLinter::CheckForNonConstReference(const CleansedLines& clean_lines,
             RegexCompile(R"(\s*::(?:[\w<>]|::)+\s*&\s*\S)");
         static const regex_code RE_PATTERN_STARTS_WITH_COLONS2 =
             RegexCompile(R"(\s*[a-zA-Z_]([\w<>]|::)+\s*&\s*\S)");
-        if (RegexMatch(RE_PATTERN_STARTS_WITH_COLONS, line, m_re_result_temp)) {
+        if (RegexMatch(RE_PATTERN_STARTS_WITH_COLONS, line)) {
             // previous_line\n + ::current_line
             previous = RegexSearch(
                             R"(\b((?:const\s*)?(?:[\w<>]|::)+[\w<>])\s*$)",
                             clean_lines.GetElidedAt(linenum - 1), m_re_result);
-        } else if (RegexMatch(RE_PATTERN_STARTS_WITH_COLONS2, line, m_re_result_temp)) {
+        } else if (RegexMatch(RE_PATTERN_STARTS_WITH_COLONS2, line)) {
             // previous_line::\n + current_line
             previous = RegexSearch(
                             R"(\b((?:const\s*)?(?:[\w<>]|::)+::)\s*$)",
@@ -3225,15 +3218,15 @@ void FileLinter::CheckForNonConstReference(const CleansedLines& clean_lines,
         size_t min_line = (linenum >= 10) ? linenum - 10 : 0;
         for (size_t i = linenum - 1; i > min_line; i--) {
             const std::string& previous_line = clean_lines.GetElidedAt(i);
-            if (!RegexSearch(R"([),]\s*$)", previous_line, m_re_result_temp))
+            if (!RegexSearch(R"([),]\s*$)", previous_line))
                 break;
-            if (RegexMatch(R"(^\s*:\s+\S)", previous_line, m_re_result_temp))
+            if (RegexMatch(R"(^\s*:\s+\S)", previous_line))
                 return;
         }
     }
 
     // Avoid preprocessors
-    if (RegexSearch(R"(\\\s*$)", line, m_re_result_temp))
+    if (RegexSearch(R"(\\\s*$)", line))
         return;
 
     // Avoid constructor initializer lists
@@ -3247,35 +3240,34 @@ void FileLinter::CheckForNonConstReference(const CleansedLines& clean_lines,
     // We also accept & in static_assert, which looks like a function but
     // it's actually a declaration expression.
 
-    if (RegexSearch(RE_PATTERN_ALLOWED_FUNCTIONS, line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_ALLOWED_FUNCTIONS, line)) {
         return;
-    } else if (!RegexSearch(R"(\S+\([^)]*$)", line, m_re_result_temp)) {
+    } else if (!RegexSearch(R"(\S+\([^)]*$)", line)) {
         // Don't see an allowed function on this line.  Actually we
         // didn't see any function name on this line, so this is likely a
         // multi-line parameter list.  Try a bit harder to catch this case.
         for (size_t i = 0; i < 2; i++) {
             if (linenum > i &&
                 RegexSearch(RE_PATTERN_ALLOWED_FUNCTIONS,
-                            clean_lines.GetElidedAt(linenum - i - 1),
-                            m_re_result_temp))
+                            clean_lines.GetElidedAt(linenum - i - 1)))
                 return;
         }
     }
 
     static const regex_code RE_PATTERN_FUNC_BODY =
         RegexCompile("{[^}]*}");
-    RegexReplace(RE_PATTERN_FUNC_BODY, " ", &line, m_re_result_temp);  // exclude function body
+    RegexReplace(RE_PATTERN_FUNC_BODY, " ", &line);  // exclude function body
     while (true) {
         bool matched = RegexSearch(RE_REF_PARAM, line, m_re_result);
         if (!matched)
             break;
         std::string parameter = GetMatchStr(m_re_result, line, 1);
-        if (!RegexMatch(RE_CONST_REF_PARAM, parameter, m_re_result_temp) &&
-            !RegexMatch(RE_REF_STREAM_PARAM, parameter, m_re_result_temp)) {
+        if (!RegexMatch(RE_CONST_REF_PARAM, parameter) &&
+            !RegexMatch(RE_REF_STREAM_PARAM, parameter)) {
             Error(linenum, "runtime/references", 2,
                   "Is this a non-const reference? "
                   "If so, make const or use a pointer: " +
-                  RegexReplace(" *<", "<", parameter, m_re_result_temp));
+                  RegexReplace(" *<", "<", parameter));
         }
         line = line.substr(GetMatchEnd(m_re_result, 0));
     }
@@ -3292,14 +3284,14 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
     if (StrContain(line, "printf")) {
         static const regex_code RE_PATTERN_PRINTF_Q =
             RegexCompile(R"(printf\s*\(.*".*%[-+ ]?\d*q)");
-        if (RegexSearch(RE_PATTERN_PRINTF_Q, line, m_re_result_temp)) {
+        if (RegexSearch(RE_PATTERN_PRINTF_Q, line)) {
             Error(linenum, "runtime/printf_format", 3,
                 "%q in format strings is deprecated.  Use %ll instead.");
         }
 
         static const regex_code RE_PATTERN_PRINTF_N =
             RegexCompile(R"(printf\s*\(.*".*%\d+\$)");
-        if (RegexSearch(RE_PATTERN_PRINTF_N, line, m_re_result_temp)) {
+        if (RegexSearch(RE_PATTERN_PRINTF_N, line)) {
             Error(linenum, "runtime/printf_format", 2,
                 "%N$ formats are unconventional.  Try rewriting to avoid them.");
         }
@@ -3336,7 +3328,7 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
                      "|float|double|signed|unsigned"
                      "|schar|u?int8|u?int16|u?int32|u?int64)"
                      R"(\s+(register|static|extern|typedef)\b)");
-    if (RegexSearch(RE_PATTERN_STORAGE_CLASS, elided, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_STORAGE_CLASS, elided)) {
         Error(linenum, "build/storage_class", 5,
               "Storage-class specifier (static, extern, typedef, etc) should be "
               "at the beginning of the declaration.");
@@ -3344,28 +3336,28 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
 
     static const regex_code RE_PATTERN_ENDIF_COMMENT =
         RegexCompile(R"(\s*#\s*endif\s*[^/\s]+)");
-    if (RegexMatch(RE_PATTERN_ENDIF_COMMENT, elided, m_re_result_temp)) {
+    if (RegexMatch(RE_PATTERN_ENDIF_COMMENT, elided)) {
         Error(linenum, "build/endif_comment", 5,
               "Uncommented text after #endif is non-standard.  Use a comment.");
     }
 
     static const regex_code RE_PATTERN_FORWARD_DECL =
         RegexCompile(R"(\s*class\s+(\w+\s*::\s*)+\w+\s*;)");
-    if (RegexMatch(RE_PATTERN_FORWARD_DECL, elided, m_re_result_temp)) {
+    if (RegexMatch(RE_PATTERN_FORWARD_DECL, elided)) {
         Error(linenum, "build/forward_decl", 5,
               "Inner-style forward declarations are invalid.  Remove this line.");
     }
 
     static const regex_code RE_PATTERN_DEPRECATED =
         RegexCompile(R"((\w+|[+-]?\d+(\.\d*)?)\s*(<|>)\?=?\s*(\w+|[+-]?\d+)(\.\d*)?)");
-    if (RegexSearch(RE_PATTERN_DEPRECATED, elided, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_DEPRECATED, elided)) {
         Error(linenum, "build/deprecated", 3,
               ">? and <? (max and min) operators are non-standard and deprecated.");
     }
 
     static const regex_code RE_PATTERN_CONST_STR_MEMBER =
         RegexCompile(R"(^\s*const\s*string\s*&\s*\w+\s*;)");
-    if (RegexSearch(RE_PATTERN_CONST_STR_MEMBER, elided, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_CONST_STR_MEMBER, elided)) {
         // TODO(unknown): Could it be expanded safely to arbitrary references,
         // without triggering too many false positives? The first
         // attempt triggered 5 warnings for mostly benign code in the regtest, hence
@@ -3449,12 +3441,12 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
         RegexCompile(R"(\bstd\s*::\s*initializer_list\b)");
     bool initializer_list_constructor =
             onearg_constructor &&
-            RegexSearch(RE_PATTERN_INITIALIZER_LIST, constructor_args[0], m_re_result_temp);
+            RegexSearch(RE_PATTERN_INITIALIZER_LIST, constructor_args[0]);
     bool copy_constructor =
             onearg_constructor &&
             RegexMatch(R"(((const\s+(volatile\s+)?)?|(volatile\s+(const\s+)?))?)" +
                        base_classname + R"((\s*<[^>]*>)?(\s+const)?\s*(?:<\w+>\s*)?&)",
-                       StrStrip(constructor_args[0]), m_re_result_temp);
+                       StrStrip(constructor_args[0]));
 
     if (!is_marked_explicit &&
             onearg_constructor &&
@@ -3474,7 +3466,7 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
 void FileLinter::CheckVlogArguments(const std::string& elided_line, size_t linenum) {
     static const regex_code RE_PATTERN_VLOG_ARG =
         RegexCompile(R"(\bVLOG\((INFO|ERROR|WARNING|DFATAL|FATAL)\))");
-    if (RegexSearch(RE_PATTERN_VLOG_ARG, elided_line, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_VLOG_ARG, elided_line)) {
         Error(linenum, "runtime/vlog", 5,
               "VLOG() should be used with numeric verbosity level.  "
               "Use LOG() if you want symbolic severity levels.");
@@ -3518,7 +3510,7 @@ void FileLinter::CheckInvalidIncrement(const std::string& elided_line, size_t li
     // Matches invalid increment: *count++, which moves pointer instead of
     // incrementing a value.
     static const regex_code RE_INVALID_INCREMENT = RegexCompile(R"(^\s*\*\w+(\+\+|--);)");
-    if (RegexMatch(RE_INVALID_INCREMENT, elided_line, m_re_result_temp)) {
+    if (RegexMatch(RE_INVALID_INCREMENT, elided_line)) {
         Error(linenum, "runtime/invalid_increment", 5,
               "Changing pointer instead of value (or unused value of operator*).");
     }
@@ -3526,7 +3518,7 @@ void FileLinter::CheckInvalidIncrement(const std::string& elided_line, size_t li
 
 void FileLinter::CheckMakePairUsesDeduction(const std::string& elided_line, size_t linenum) {
     static const regex_code RE_EXPLICIT_MAKEPAIR = RegexCompile(R"(\bmake_pair\s*<)");
-    if (RegexSearch(RE_EXPLICIT_MAKEPAIR, elided_line, m_re_result_temp)) {
+    if (RegexSearch(RE_EXPLICIT_MAKEPAIR, elided_line)) {
         Error(linenum, "build/explicit_make_pair",
               4,  // 4 = high confidence
               "For C++11-compatibility, omit template arguments from make_pair"
@@ -3546,15 +3538,15 @@ void FileLinter::CheckRedundantVirtual(const CleansedLines& clean_lines,
     // are only used in class base-specifier and do not apply to member
     // functions.
     if (RegexSearch(R"(\b(public|protected|private)\s+$)",
-                    GetMatchStr(m_re_result, elided_line, 1), m_re_result_temp) ||
+                    GetMatchStr(m_re_result, elided_line, 1)) ||
         RegexMatch(R"(^\s+(public|protected|private)\b)",
-                   GetMatchStr(m_re_result, elided_line, 3), m_re_result_temp))
+                   GetMatchStr(m_re_result, elided_line, 3)))
         return;
 
     // Ignore the "virtual" keyword from virtual base classes.  Usually
     // there is a column on the same line in these cases (virtual base
     // classes are rare in google3 because multiple inheritance is rare).
-    if (RegexMatch(R"(^.*[^:]:[^:].*$)", elided_line, m_re_result_temp))
+    if (RegexMatch(R"(^.*[^:]:[^:].*$)", elided_line))
         return;
 
     // Look for the next opening parenthesis.  This is the start of the
@@ -3567,8 +3559,9 @@ void FileLinter::CheckRedundantVirtual(const CleansedLines& clean_lines,
     size_t start_col = GetMatchSize(m_re_result, 2);
     for (size_t start_line = linenum;
             start_line < MIN(linenum + 3, clean_lines.NumLines()); start_line++) {
-        std::string line = clean_lines.GetElidedAt(start_line).substr(start_col);
-        bool parameter_list = RegexMatch(R"(^([^(]*)\()", line, m_re_result);
+        const std::string& line = clean_lines.GetElidedAt(start_line);
+        bool parameter_list = RegexMatchWithRange(R"(^([^(]*)\()", line,
+                                                  start_col, line.size() - start_col, m_re_result);
         if (parameter_list) {
             // Match parentheses to find the end of the parameter list
             end_line = start_line;
@@ -3586,18 +3579,20 @@ void FileLinter::CheckRedundantVirtual(const CleansedLines& clean_lines,
     // (possibly on the next few lines).
     for (size_t i = end_line;
             i < MIN(end_line + 3, clean_lines.NumLines()); i++) {
-        std::string line = clean_lines.GetElidedAt(i).substr(end_col);
-        match = RegexSearch(R"(\b(override|final)\b)", line, m_re_result);
+        const std::string& line = clean_lines.GetElidedAt(i);
+        match = RegexSearchWithRange(R"(\b(override|final)\b)", line,
+                                     end_col, line.size() - end_col, m_re_result);
         if (match) {
             Error(linenum, "readability/inheritance", 4,
                   "\"virtual\" is redundant since function is "
-                  "already declared as \"" + GetMatchStr(m_re_result, line, 1) + "\"");
+                  "already declared as \"" + GetMatchStr(m_re_result, line, 1, end_col) + "\"");
         }
 
+        bool matched = RegexSearchWithRange(R"([^\w]\s*$)", line, end_col, line.size() - end_col);
         // Set end_col to check whole lines after we are done with the
         // first line.
         end_col = 0;
-        if (RegexSearch(R"([^\w]\s*$)", line, m_re_result_temp))
+        if (matched)
             break;
     }
 }
@@ -3621,8 +3616,8 @@ void FileLinter::CheckRedundantOverrideOrFinal(const CleansedLines& clean_lines,
     }
 
     // Check that at most one of "override" or "final" is present, not both
-    if (RegexSearch(RE_PATTERN_OVERRIDE, fragment, m_re_result_temp) &&
-        RegexSearch(R"(\bfinal\b)", fragment, m_re_result_temp)) {
+    if (RegexSearch(RE_PATTERN_OVERRIDE, fragment) &&
+        RegexSearch(R"(\bfinal\b)", fragment)) {
         Error(linenum, "readability/inheritance", 4,
                               "\"override\" is redundant since function is "
                               "already declared as \"final\"");
@@ -3861,7 +3856,7 @@ void FileLinter::CheckForIncludeWhatYouUse(const CleansedLines& clean_lines,
         // Match 'std::map<type>(...)', but not 'map<type>(...)''
         static const regex_code RE_PATTERNS_MAP_TEMPLATES =
             RegexJitCompile(R"((std\b::\bmap\s*\<)|(^(std\b::\b)map\b\(\s*\<))");
-        if (RegexSearch(RE_PATTERNS_MAP_TEMPLATES, line, m_re_result_temp))
+        if (RegexSearch(RE_PATTERNS_MAP_TEMPLATES, line))
             required["map"] = { linenum, "map<>" };
 
         // Other scripts may reach in and modify this pattern.
@@ -3899,7 +3894,7 @@ void FileLinter::CheckHeaderFileIncluded(IncludeState* include_state) {
     std::string basename = m_file.filename().string();
     static const regex_code RE_PATTERN_TEST_SUFFIX =
         RegexCompile("(_test|_regtest|_unittest)$");
-    if (RegexSearch(RE_PATTERN_TEST_SUFFIX, basename, m_re_result_temp))
+    if (RegexSearch(RE_PATTERN_TEST_SUFFIX, basename))
         return;
 
     std::string message = "";

--- a/src/line_utils.cpp
+++ b/src/line_utils.cpp
@@ -114,10 +114,11 @@ void FindEndOfExpressionInLine(const std::string& line,
 
 const std::string& CloseExpression(const CleansedLines& clean_lines, size_t* linenum, size_t* pos) {
     const std::string& line = clean_lines.GetElidedAt(*linenum);
-    char c = line[*pos];
-    std::string exp = line.substr(*pos);
+    const char* cp = &line[*pos];
+    const char c = *cp;
+    const char c2 = *(cp + 1);
     if (!(c == '(' || c == '{' || c == '[' || c == '<') ||
-        (exp.starts_with("<<") || exp.starts_with("<="))) {
+        (c == '<' && (c2 == '<' || c2 == '='))) {
         *linenum = clean_lines.NumLines();
         *pos = INDEX_NONE;
         return line;

--- a/src/line_utils.cpp
+++ b/src/line_utils.cpp
@@ -6,10 +6,9 @@
 #include "string_utils.h"
 
 size_t GetIndentLevel(const std::string& line) {
-    regex_match m;
     static const regex_code RE_PATTERN_INDENT =
         RegexCompile(R"(^( *)\S)");
-    regex_match re_result = RegexCreateMatchData(RE_PATTERN_INDENT);
+    thread_local regex_match re_result = RegexCreateMatchData(RE_PATTERN_INDENT);
     bool indent = RegexMatch(RE_PATTERN_INDENT, line, re_result);
     if (indent)
         return GetMatchSize(re_result, 1);
@@ -39,7 +38,7 @@ void FindEndOfExpressionInLine(const std::string& line,
                         return;
                     }
                 }
-            } else if (i > 0 && RegexSearch(RE_PATTERN_OPERATOR, line.substr(0, i))) {
+            } else if (i > 0 && RegexSearchWithRange(RE_PATTERN_OPERATOR, line, 0, i)) {
                 // operator<, don't add to stack
                 continue;
             } else {
@@ -78,7 +77,7 @@ void FindEndOfExpressionInLine(const std::string& line,
 
             // Ignore "->" and operator functions
             if (i > 0 &&
-                (line[i - 1] == '-' || RegexSearch(RE_PATTERN_OPERATOR, line.substr(0, i - 1))))
+                (line[i - 1] == '-' || RegexSearchWithRange(RE_PATTERN_OPERATOR, line, 0, i - 1)))
                 continue;
 
             // Pop the stack if there is a matching '<'.  Otherwise, ignore
@@ -154,6 +153,8 @@ const std::string& CloseExpression(const CleansedLines& clean_lines, size_t* lin
 void FindStartOfExpressionInLine(const std::string& line,
                                  size_t* endpos,
                                  std::stack<char>* stack) {
+    regex_match re_result = RegexCreateMatchData(RE_PATTERN_OPERATOR);
+
     size_t i = *endpos;
     while (i != INDEX_NONE) {
         char c = line[i];
@@ -167,7 +168,7 @@ void FindStartOfExpressionInLine(const std::string& line,
             if (i > 0 &&
                 (line[i - 1] == '-' ||
                  RegexMatch(R"(\s>=\s)", line.substr(i - 1)) ||
-                 RegexSearch(RE_PATTERN_OPERATOR, line.substr(0, i))))
+                 RegexSearchWithRange(RE_PATTERN_OPERATOR, line, 0, i)))
                 i--;
             else
                 stack->push('>');

--- a/src/line_utils.cpp
+++ b/src/line_utils.cpp
@@ -34,7 +34,6 @@ void FindEndOfExpressionInLine(const std::string& line,
                     stack->pop();
                     if (stack->empty()) {
                         *startpos = INDEX_NONE;
-                        *stack = {};
                         return;
                     }
                 }
@@ -54,7 +53,6 @@ void FindEndOfExpressionInLine(const std::string& line,
                 stack->pop();
             if (stack->empty()) {
                 *startpos = INDEX_NONE;
-                *stack = {};
                 return;
             }
             if ((stack->top() == '(' && c == ')') ||
@@ -63,7 +61,6 @@ void FindEndOfExpressionInLine(const std::string& line,
                 stack->pop();
                 if (stack->empty()) {
                     *startpos = i + 1;
-                    *stack = {};
                     return;
                 }
             } else {
@@ -87,7 +84,6 @@ void FindEndOfExpressionInLine(const std::string& line,
                     stack->pop();
                     if (stack->empty()) {
                         *startpos = i + 1;
-                        *stack = {};
                         return;
                     }
                 }
@@ -100,7 +96,6 @@ void FindEndOfExpressionInLine(const std::string& line,
                 stack->pop();
             if (stack->empty()) {
                 *startpos = INDEX_NONE;
-                *stack = {};
                 return;
             }
         }
@@ -184,7 +179,6 @@ void FindStartOfExpressionInLine(const std::string& line,
                     stack->pop();
                     if (stack->empty()) {
                         *endpos = i;
-                        *stack = {};
                         return;
                     }
                 }
@@ -198,7 +192,6 @@ void FindStartOfExpressionInLine(const std::string& line,
                 stack->pop();
             if (stack->empty()) {
                 *endpos = INDEX_NONE;
-                *stack = {};
                 return;
             }
             if ((c == '(' && stack->top() == ')') ||
@@ -207,7 +200,6 @@ void FindStartOfExpressionInLine(const std::string& line,
                 stack->pop();
                 if (stack->empty()) {
                     *endpos = i;
-                    *stack = {};
                     return;
                 }
             } else {
@@ -224,7 +216,6 @@ void FindStartOfExpressionInLine(const std::string& line,
                 stack->pop();
             if (stack->empty()) {
                 *endpos = INDEX_NONE;
-                *stack = {};
                 return;
             }
         }

--- a/src/nest_info.cpp
+++ b/src/nest_info.cpp
@@ -54,7 +54,7 @@ void ClassInfo::CheckBegin(const CleansedLines& clean_lines,
         RegexCompile("(^|[^:]):($|[^:])");
 
     // Look for a bare ':'
-    if (RegexSearch(RE_PATTERN_CHECK_BEGIN, clean_lines.GetElidedAt(linenum), m_re_result))
+    if (RegexSearch(RE_PATTERN_CHECK_BEGIN, clean_lines.GetElidedAt(linenum)))
         m_is_derived = true;
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -19,7 +19,7 @@
 namespace fs = std::filesystem;
 
 // The version of cpplint.cpp
-static const char* CPPLINT_CPP_VERSION = "0.1.0";
+static const char* CPPLINT_CPP_VERSION = "0.2.0";
 
 // The version of cpplint.py
 static const char* ORIGINAL_VERSION = "1.7";

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -759,14 +759,14 @@ static void ParseFilterSelector(const std::string& filter,
         Filename is either a filename or empty if all files are meant.
         Line is either a line in filename or -1 if all lines are meant.
     */
-    size_t colon_pos = filter.find(':');
+    size_t colon_pos = filter.find(':', 1);
     if (colon_pos == std::string::npos) {
-        category = filter;
+        category = filter.substr(1);
         file = "";
         *line = INDEX_NONE;
         return;
     }
-    category = filter.substr(0, colon_pos);
+    category = filter.substr(1, colon_pos - 1);
     size_t second_colon_pos = filter.find(':', colon_pos + 1);
     if (second_colon_pos == std::string::npos) {
         file = filter.substr(colon_pos + 1, std::string::npos);
@@ -782,27 +782,24 @@ static void ParseFilterSelector(const std::string& filter,
 bool Options::ShouldPrintError(const std::string& category,
                                const std::string& filename, size_t linenum) {
     bool is_filtered = false;
-    for (const std::string& one_filter : Filters()) {
-        std::string filter_without_dot = &one_filter[1];
+    for (const std::string& filter : Filters()) {
         std::string filter_cat;
         std::string filter_file;
         size_t filter_line;
-        ParseFilterSelector(filter_without_dot, filter_cat, filter_file, &filter_line);
+        ParseFilterSelector(filter, filter_cat, filter_file, &filter_line);
         bool category_match = category.starts_with(filter_cat);
         bool file_match = filter_file.empty() || filter_file == filename;
         bool line_match = filter_line == linenum || filter_line == INDEX_NONE;
 
-        if (one_filter.starts_with('-')) {
+        if (filter.starts_with('-')) {
             if (category_match && file_match && line_match)
                 is_filtered = true;
-        } else if (one_filter.starts_with('+')) {
+        } else if (filter.starts_with('+')) {
             if (category_match && file_match && line_match)
                 is_filtered = false;
         } else {
             assert(false);  // should have been checked for in SetFilter.
         }
     }
-    if (is_filtered)
-        return false;
-    return true;
+    return !is_filtered;
 }

--- a/src/regex_utils.cpp
+++ b/src/regex_utils.cpp
@@ -1,6 +1,7 @@
 #include "regex_utils.h"
 #include <ctype.h>
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <utility>

--- a/src/regex_utils.cpp
+++ b/src/regex_utils.cpp
@@ -27,6 +27,19 @@ pcre2_code* RegexCompileBase(const std::string& regex, uint32_t options) noexcep
     return code_ptr;
 }
 
+regex_code RegexJitCompile(const std::string& regex, uint32_t options) noexcept {
+    pcre2_code* ret = RegexCompileBase(regex, options);
+
+    int result = pcre2_jit_compile(ret, PCRE2_JIT_COMPLETE);
+    if (result != 0) {
+        std::cerr << "PCRE2 JIT compilation failed. " <<
+            " Error: " << result << ", Pattern: " << regex << std::endl;
+        exit(1);
+    }
+
+    return regex_code(ret);
+}
+
 static inline bool pcre2_match_priv(const pcre2_code* re, const std::string& str,
                                     pcre2_match_data* match, uint32_t flags = REGEX_FLAGS_DEFAULT) {
     int rc = pcre2_match(

--- a/src/regex_utils.cpp
+++ b/src/regex_utils.cpp
@@ -27,6 +27,7 @@ pcre2_code* RegexCompileBase(const std::string& regex, uint32_t options) noexcep
     return code_ptr;
 }
 
+#ifdef SUPPORT_JIT
 regex_code RegexJitCompile(const std::string& regex, uint32_t options) noexcept {
     pcre2_code* ret = RegexCompileBase(regex, options);
 
@@ -39,6 +40,7 @@ regex_code RegexJitCompile(const std::string& regex, uint32_t options) noexcept 
 
     return regex_code(ret);
 }
+#endif
 
 static inline bool pcre2_match_priv(const pcre2_code* re, const std::string& str,
                                     pcre2_match_data* match, uint32_t flags = REGEX_FLAGS_DEFAULT) {

--- a/src/regex_utils.cpp
+++ b/src/regex_utils.cpp
@@ -27,21 +27,6 @@ pcre2_code* RegexCompileBase(const std::string& regex, uint32_t options) noexcep
     return code_ptr;
 }
 
-#ifdef SUPPORT_JIT
-regex_code RegexJitCompile(const std::string& regex, uint32_t options) noexcept {
-    pcre2_code* ret = RegexCompileBase(regex, options);
-
-    int result = pcre2_jit_compile(ret, PCRE2_JIT_COMPLETE);
-    if (result != 0) {
-        std::cerr << "PCRE2 JIT compilation failed. " <<
-            " Error: " << result << ", Pattern: " << regex << std::endl;
-        exit(1);
-    }
-
-    return regex_code(ret);
-}
-#endif
-
 static inline bool pcre2_match_priv(const pcre2_code* re, const std::string& str,
                                     PCRE2_SIZE startoffset, PCRE2_SIZE length,
                                     pcre2_match_data* match,
@@ -150,141 +135,109 @@ bool RegexSearchWithRange(const regex_code& regex, const std::string& str,
                             result.get(), flags);
 }
 
-static std::vector<char> regex_replace_base(
+template<typename MatchFunc>
+static void regex_replace_base(
+        MatchFunc re_match,
         const pcre2_code* re, const std::string& fmt,
         const std::string& str,
-        pcre2_match_data* match_data,
-        PCRE2_SIZE* outlength,
+        std::string* result_str,
         bool* replaced, bool replace_all) {
     *replaced = false;
-    uint32_t options = PCRE2_SUBSTITUTE_EXTENDED;
-    if (replace_all)
-        options |= PCRE2_SUBSTITUTE_GLOBAL;
 
-    // Calculate the output size
-    size_t buffer_size = MAX(str.length(), 1);  // Starting buffer size
-    *outlength = buffer_size;
-    std::vector<char> buffer(buffer_size);
+    // Position to start the search
+    PCRE2_SIZE start_offset = 0;
+
+    // Get matched ranges and the length of replaced string
+    std::vector<std::pair<PCRE2_SIZE, PCRE2_SIZE>>* matched_ranges = nullptr;
+    size_t result_length = 0;
     while (true) {
-        int result = pcre2_substitute(
+        int rc = re_match(
             re,
-            reinterpret_cast<PCRE2_SPTR>(str.c_str()),
+            (PCRE2_SPTR)str.c_str(),
             str.length(),
-            0,
-            options,
-            match_data,
-            nullptr,
-            reinterpret_cast<PCRE2_SPTR>(fmt.c_str()),
-            fmt.length(),
-            reinterpret_cast<PCRE2_UCHAR8*>(buffer.data()),
-            outlength);
+            start_offset,
+            REGEX_OPTIONS_DEFAULT,
+            re_result_temp.get(),
+            nullptr);
 
-        if (result == PCRE2_ERROR_NOMEMORY) {
-            // Increase buffer size and try again
-            buffer_size *= 2;
-            buffer.resize(buffer_size);
-            *outlength = buffer_size;
-        } else if (result >= 0) {
-            // Success
-            *replaced = result > 0;
-            break;
-        } else {
-            // Substitution failed, return original string
-            break;
+        if (rc < 0) {
+            if (rc == PCRE2_ERROR_NOMATCH) {
+                result_length += str.length() - start_offset;
+                break;  // No more matches
+            } else {
+                std::cerr << "PCRE2 matching error " << rc << std::endl;
+                break;
+            }
         }
+
+        // Save the matched range.
+        PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(re_result_temp.get());
+        PCRE2_SIZE match_start = ovector[0];
+        PCRE2_SIZE match_end = ovector[1];
+        if (!matched_ranges)
+            matched_ranges = new std::vector<std::pair<PCRE2_SIZE, PCRE2_SIZE>>({});
+        matched_ranges->emplace_back(match_start, match_end);
+        result_length += match_start - start_offset + fmt.size();
+
+        // Update previous_end and start_offset to continue after the current match
+        start_offset = match_end;
+
+        *replaced = true;
+
+        // Handle empty matches by incrementing the offset
+        if (match_start == match_end)
+            start_offset++;
+
+        if (start_offset >= str.length() || !replace_all)
+            break;
     }
-    return buffer;
-}
 
-inline std::string regex_replace_base(const pcre2_code* re, const std::string& fmt,
-                                      const std::string& str,
-                                      pcre2_match_data* match_data,
-                                      bool* replaced, bool replace_all) {
-    PCRE2_SIZE outlength = 0;
-    std::vector<char> buffer =
-        regex_replace_base(re, fmt, str, match_data, &outlength, replaced, replace_all);
-    if (*replaced)
-        return std::string(buffer.data(), outlength);
-    else
-        return str;
-}
+    if (!matched_ranges)
+        return;  // Returns input string as it is.
 
-inline std::string regex_replace_base(const pcre2_code* re, const std::string& fmt,
-                                      const std::string& str,
-                                      pcre2_match_data* match_data, bool replace_all) {
-    bool replaced = false;
-    PCRE2_SIZE outlength = 0;
-    std::vector<char> buffer =
-        regex_replace_base(re, fmt, str, match_data, &outlength, &replaced, replace_all);
-    if (replaced)
-        return std::string(buffer.data(), outlength);
-    else
-        return str;
-}
+    // Create return value
+    std::string new_str;
+    new_str.resize(result_length);
+    char* result_p = new_str.data();
+    const char* str_p = str.data();
+    const char* fmt_p = fmt.data();
+    PCRE2_SIZE prev_end = 0;
 
-inline void regex_replace_base(const pcre2_code* re, const std::string& fmt,
-                               std::string* str,
-                               pcre2_match_data* match_data, bool replace_all) {
-    bool replaced = false;
-    PCRE2_SIZE outlength = 0;
-    std::vector<char> buffer =
-        regex_replace_base(re, fmt, *str, match_data, &outlength, &replaced, replace_all);
-    if (replaced)
-        *str = std::string(buffer.data(), outlength);
-}
+    for (const std::pair<PCRE2_SIZE, PCRE2_SIZE>& range : (*matched_ranges)) {
+        memcpy(result_p, str_p + prev_end, range.first - prev_end);
+        result_p += range.first - prev_end;
+        memcpy(result_p, fmt_p, fmt.size());
+        result_p += fmt.size();
+        prev_end = range.second;
+    }
 
-inline void regex_replace_base(const pcre2_code* re, const std::string& fmt,
-                               std::string* str,
-                               pcre2_match_data* match_data,
-                               bool* replaced, bool replace_all) {
-    PCRE2_SIZE outlength = 0;
-    std::vector<char> buffer =
-        regex_replace_base(re, fmt, *str, match_data, &outlength, replaced, replace_all);
-    if (*replaced)
-        *str = std::string(buffer.data(), outlength);
-}
+    if (prev_end != str.length())
+        memcpy(result_p, str_p + prev_end, str.length() - prev_end);
 
-std::string RegexReplace(const std::string& regex, const std::string& fmt,
-                         const std::string& str, bool replace_all) {
-    regex_code re = RegexCompile(regex);
-    if (!re) return str;
-    return regex_replace_base(re.get(), fmt, str,
-                              re_result_temp.get(), replace_all);
-}
-
-std::string RegexReplace(const regex_code& regex, const std::string& fmt,
-                         const std::string& str, bool replace_all) {
-    if (!regex) return str;
-    return regex_replace_base(regex.get(), fmt, str,
-                              re_result_temp.get(), replace_all);
+    *result_str = std::move(new_str);
+    delete matched_ranges;
 }
 
 std::string RegexReplace(const regex_code& regex, const std::string& fmt,
                          const std::string& str,
                          bool* replaced, bool replace_all) {
     if (!regex) return str;
-    return regex_replace_base(regex.get(), fmt, str, re_result_temp.get(), replaced, replace_all);
-}
-
-void RegexReplace(const regex_code& regex, const std::string& fmt,
-                  std::string* str,
-                  bool replace_all) {
-    if (!regex) return;
-    regex_replace_base(regex.get(), fmt, str, re_result_temp.get(), replace_all);
+    std::string result = str;
+    regex_replace_base(pcre2_match, regex.get(), fmt, str, &result, replaced, replace_all);
+    return result;
 }
 
 void RegexReplace(const regex_code& regex, const std::string& fmt,
                   std::string* str,
                   bool* replaced, bool replace_all) {
     if (!regex) return;
-    regex_replace_base(regex.get(), fmt, str, re_result_temp.get(), replaced, replace_all);
+    regex_replace_base(pcre2_match, regex.get(), fmt, *str, str, replaced, replace_all);
 }
 
 std::string RegexEscape(const std::string& str) {
     static const regex_code RE_PATTERN_ESCAPE = RegexCompile(R"([-[\]{}()*+?.,\^$|#\s])");
     return RegexReplace(RE_PATTERN_ESCAPE, R"(\$&)", str);
 }
-
 
 std::vector<std::string> RegexSplit(const std::string& regex, const std::string& str) {
     regex_code re = RegexCompile(regex);
@@ -295,10 +248,6 @@ std::vector<std::string> RegexSplit(const std::string& regex, const std::string&
         return result;
     }
 
-    regex_match match_data(
-        pcre2_match_data_create_from_pattern(re.get(), nullptr));
-
-    // Position to start the search
     // Position to start the search
     PCRE2_SIZE start_offset = 0;
     PCRE2_SIZE previous_end = 0;
@@ -310,7 +259,7 @@ std::vector<std::string> RegexSplit(const std::string& regex, const std::string&
             str.length(),
             start_offset,
             REGEX_OPTIONS_DEFAULT,
-            match_data.get(),
+            re_result_temp.get(),
             nullptr);
 
         if (rc < 0) {
@@ -327,7 +276,7 @@ std::vector<std::string> RegexSplit(const std::string& regex, const std::string&
         }
 
         // Retrieve the starting position of the match
-        PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(match_data.get());
+        PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(re_result_temp.get());
         PCRE2_SIZE match_start = ovector[0];
         PCRE2_SIZE match_end = ovector[1];
 
@@ -350,3 +299,63 @@ std::vector<std::string> RegexSplit(const std::string& regex, const std::string&
     }
     return result;
 }
+
+#ifdef SUPPORT_JIT
+regex_code RegexJitCompile(const std::string& regex, uint32_t options) noexcept {
+    pcre2_code* ret = RegexCompileBase(regex, options);
+
+    int result = pcre2_jit_compile(ret, PCRE2_JIT_COMPLETE);
+    if (result != 0) {
+        std::cerr << "PCRE2 JIT compilation failed. " <<
+            " Error: " << result << ", Pattern: " << regex << std::endl;
+        exit(1);
+    }
+
+    return regex_code(ret);
+}
+
+static inline bool pcre2_jit_match_priv(const pcre2_code* re, const std::string& str,
+                                        PCRE2_SIZE startoffset, PCRE2_SIZE length,
+                                        pcre2_match_data* match,
+                                        uint32_t flags = REGEX_FLAGS_DEFAULT) {
+    int rc = pcre2_jit_match(
+        re,
+        reinterpret_cast<PCRE2_SPTR>(str.c_str()) + startoffset,
+        length,
+        0,
+        flags,
+        match,
+        nullptr);
+    return rc >= 0;
+}
+
+bool RegexJitSearch(const regex_code& regex, const std::string& str,
+                    uint32_t flags) noexcept {
+    if (!regex) return false;
+    return pcre2_jit_match_priv(regex.get(), str, 0, str.size(),
+                                re_result_temp.get(), flags);
+}
+
+bool RegexJitSearch(const regex_code& regex, const std::string& str,
+                    regex_match& result,
+                    uint32_t flags) noexcept {
+    if (!regex) return false;
+    return pcre2_jit_match_priv(regex.get(), str, 0, str.size(), result.get(), flags);
+}
+
+std::string RegexJitReplace(const regex_code& regex, const std::string& fmt,
+                            const std::string& str,
+                            bool* replaced, bool replace_all) {
+    if (!regex) return str;
+    std::string result = str;
+    regex_replace_base(pcre2_jit_match, regex.get(), fmt, str, &result, replaced, replace_all);
+    return result;
+}
+
+void RegexJitReplace(const regex_code& regex, const std::string& fmt,
+                     std::string* str,
+                     bool* replaced, bool replace_all) {
+    if (!regex) return;
+    regex_replace_base(pcre2_jit_match, regex.get(), fmt, *str, str, replaced, replace_all);
+}
+#endif

--- a/src/states.cpp
+++ b/src/states.cpp
@@ -83,8 +83,7 @@ bool IncludeState::IsInAlphabeticalOrder(const CleansedLines& clean_lines,
         RegexCompile(R"(^\s*#\s*include\b)");
     if ((m_last_header.compare(header_path) > 0) &&
         RegexMatch(RE_PATTERN_INCLUDE_ORDER,
-                   clean_lines.GetElidedAt(linenum - 1),
-                   m_re_result))
+                   clean_lines.GetElidedAt(linenum - 1)))
         return false;
     return true;
 }
@@ -259,11 +258,11 @@ void NestingState::UpdatePreprocessor(const std::string& line) {
         RegexCompile(R"(^\s*#\s*(else|elif)\b)");
     static const regex_code RE_PATTERN_ENDIF_MACRO =
         RegexCompile(R"(^\s*#\s*endif\b)");
-    if (RegexMatch(RE_PATTERN_IF_MACRO, line, m_re_result_temp)) {
+    if (RegexMatch(RE_PATTERN_IF_MACRO, line)) {
         // Beginning of #if block, save the nesting stack here.  The saved
         // stack will allow us to restore the parsing state in the #else case.
         m_pp_stack.push(PreprocessorInfo(m_stack));
-    } else if (RegexMatch(RE_PATTERN_ELSE_MACRO, line, m_re_result_temp)) {
+    } else if (RegexMatch(RE_PATTERN_ELSE_MACRO, line)) {
         // Beginning of #else block
         if (!m_pp_stack.empty()) {
             PreprocessorInfo& pp = m_pp_stack.top();
@@ -280,7 +279,7 @@ void NestingState::UpdatePreprocessor(const std::string& line) {
         } else {
             // TODO(unknown): unexpected #else, issue warning?
         }
-    } else if (RegexMatch(RE_PATTERN_ENDIF_MACRO, line, m_re_result_temp)) {
+    } else if (RegexMatch(RE_PATTERN_ENDIF_MACRO, line)) {
         // End of #if or #else blocks.
         if (!m_pp_stack.empty()) {
             PreprocessorInfo& pp = m_pp_stack.top();
@@ -336,7 +335,7 @@ void NestingState::Update(const CleansedLines& clean_lines,
         if (inline_asm == NO_ASM || inline_asm == END_ASM) {
             if (depth_change != 0 &&
                 inner_block->OpenParentheses() == 1 &&
-                RegexMatch(RE_PATTERN_ASM, line, m_re_result_temp)) {
+                RegexMatch(RE_PATTERN_ASM, line)) {
                 // Enter assembly block
                 inner_block->SetInlineAsm(INSIDE_ASM);
             } else {
@@ -463,13 +462,13 @@ void NestingState::Update(const CleansedLines& clean_lines,
                 RegexCompile(R"(^extern\s*"[^"]*"\s*\{)");
             if (!SeenOpenBrace()) {
                 m_stack.back()->SetSeenOpenBrace(true);
-            } else if (RegexMatch(RE_PATTERN_EXTERN, line, m_re_result_temp)) {
+            } else if (RegexMatch(RE_PATTERN_EXTERN, line)) {
                 m_block_info_buffer.push(new ExternCInfo(linenum));
                 m_stack.push_back(m_block_info_buffer.top());
             } else {
                 m_block_info_buffer.push(new BlockInfo(linenum, true));
                 m_stack.push_back(m_block_info_buffer.top());
-                if (RegexMatch(RE_PATTERN_ASM, line, m_re_result_temp))
+                if (RegexMatch(RE_PATTERN_ASM, line))
                     m_stack.back()->SetInlineAsm(BLOCK_ASM);
             }
         } else if (token[0] == ';' || token[0] == ')') {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -261,15 +261,15 @@ std::string StrToUpper(const std::string &str) {
     return upper;
 }
 
-char GetFirstNonSpace(const std::string& str) noexcept {
-    const char* start = &str[0];
+char GetFirstNonSpace(const std::string& str, size_t pos) noexcept {
+    const char* start = &str[pos];
     while (IS_SPACE(*start))
         start++;
     return *start;
 }
 
-size_t GetFirstNonSpacePos(const std::string& str) noexcept {
-    const char* start = &str[0];
+size_t GetFirstNonSpacePos(const std::string& str, size_t pos) noexcept {
+    const char* start = &str[pos];
     while (IS_SPACE(*start))
         start++;
     if (*start == '\0')

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -24,7 +24,7 @@ std::string StrBeforeChar(const std::string& str, char c) {
         }
         str_p++;
     }
-    return str.substr(0, TO_SIZE(end - start));
+    return std::string(start, end);
 }
 
 std::string StrAfterChar(const std::string& str, char c) {
@@ -47,7 +47,7 @@ std::string StrStrip(const std::string &str) {
         end--;
     if (end < start)
         return "";
-    return str.substr(TO_SIZE(start - &str[0]), TO_SIZE(end - start) + 1);
+    return std::string(start, end + 1);
 }
 
 std::string StrStrip(const std::string &str, char c) {
@@ -58,7 +58,7 @@ std::string StrStrip(const std::string &str, char c) {
     const char* end = &str[str.size() - 1];
     while (start < end && *end == c)
         end--;
-    return str.substr(TO_SIZE(start - &str[0]), TO_SIZE(end - start) + 1);
+    return std::string(start, end + 1);
 }
 
 std::string StrStrip(const char* start, const char* end) {
@@ -80,7 +80,7 @@ std::string StrRstrip(const std::string &str) {
         end--;
     if (end < start)
         return "";
-    return str.substr(0, TO_SIZE(end - start) + 1);
+    return std::string(start, end + 1);
 }
 
 std::string StrRstrip(const std::string &str, char c) {
@@ -91,7 +91,7 @@ std::string StrRstrip(const std::string &str, char c) {
         end--;
     if (end < start)
         return "";
-    return str.substr(0, TO_SIZE(end - start) + 1);
+    return std::string(start, end + 1);
 }
 
 std::string StrLstrip(const std::string &str) {
@@ -99,7 +99,7 @@ std::string StrLstrip(const std::string &str) {
     while (IS_SPACE(*start))
         start++;
     const char* end = &str[str.size()];
-    return str.substr(TO_SIZE(start - &str[0]), TO_SIZE(end - start));
+    return std::string(start, end);
 }
 
 std::string StrLstrip(const std::string &str, char c) {
@@ -107,7 +107,7 @@ std::string StrLstrip(const std::string &str, char c) {
     while (*start == c)
         start++;
     const char* end = &str[str.size()];
-    return str.substr(TO_SIZE(start - &str[0]), TO_SIZE(end - start));
+    return std::string(start, end);
 }
 
 size_t StrLstripSize(const std::string &str) {
@@ -138,7 +138,7 @@ std::vector<std::string> StrSplit(const std::string& str, size_t max_size) {
             str_p++;
         }
         const char* end = str_p;
-        split.emplace_back(str.substr(TO_SIZE(start - &str[0]), TO_SIZE(end - start)));
+        split.emplace_back(start, end);
         if (split.size() >= max_size) {
             break;
         }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -61,6 +61,17 @@ std::string StrStrip(const std::string &str, char c) {
     return str.substr(TO_SIZE(start - &str[0]), TO_SIZE(end - start) + 1);
 }
 
+std::string StrStrip(const char* start, const char* end) {
+    if (start > end) return "";
+    while (IS_SPACE(*start))
+        start++;
+    while (start <= end && IS_SPACE(*end))
+        end--;
+    if (end < start)
+        return "";
+    return std::string(start, end + 1);
+}
+
 std::string StrRstrip(const std::string &str) {
     if (str.empty()) return str;
     const char* start = &str[0];
@@ -152,21 +163,19 @@ std::vector<std::string> StrSplitBy(const std::string &str, const std::string &d
 
 std::set<std::string> ParseCommaSeparetedList(const std::string& str) {
     std::set<std::string> set = {};
-    std::string copied = str;
-    char* str_p = &copied[0];
-    char* start = str_p;
+    const char* str_p = &str[0];
+    const char* start = str_p;
 
     while (*str_p != '\0') {
         if (*str_p == ',') {
-            *str_p = '\0';
-            std::string item = StrStrip(start);
+            std::string item = StrStrip(start, str_p - 1);
             if (item.size() > 0)
                 set.insert(item);
             start = str_p + 1;
         }
         str_p++;
     }
-    std::string item = StrStrip(start);
+    std::string item = StrStrip(start, str_p - 1);
     if (item.size() > 0)
         set.insert(item);
     return set;

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -146,6 +146,27 @@ std::vector<std::string> StrSplit(const std::string& str, size_t max_size) {
     return split;
 }
 
+std::string StrSplitLast(const std::string& str) {
+    if (str.empty())
+        return "";
+
+    const char* start = &str[0];
+    const char* str_p = &str[str.size() - 1];
+    // skip white spaces
+    while (IS_SPACE(*str_p) && str_p >= start)
+        str_p--;
+
+    if (str_p < start)
+        return "";  // All characters are white spaces.
+
+    const char* end = str_p + 1;
+
+    while (!IS_SPACE(*str_p) && str_p >= start)
+        str_p--;
+
+    return std::string(str_p + 1, end);
+}
+
 std::vector<std::string> StrSplitBy(const std::string &str, const std::string &delimiter) {
     std::string copied = str;
     std::vector<std::string> tokens = {};

--- a/tests/regex_test.cpp
+++ b/tests/regex_test.cpp
@@ -121,12 +121,9 @@ TEST(RegexTest, RegexReplace2) {
             R"(\s+)" RE_PATTERN_C_COMMENTS R"((?=\W)|)"
             RE_PATTERN_C_COMMENTS ")");
 
-    regex_match re_result =
-        RegexCreateMatchData(RE_PATTERN_CLEANSE_LINE_C_COMMENTS);
-
     bool replaced;
     std::string res = RegexReplace(RE_PATTERN_CLEANSE_LINE_C_COMMENTS, "",
-                                   "        /*foo=*/true, /*bar=*/true);", re_result, &replaced);
+                                   "        /*foo=*/true, /*bar=*/true);", &replaced);
     EXPECT_EQ(true, replaced);
     EXPECT_STREQ("        true, true);", res.c_str());
 }

--- a/tests/regex_test.cpp
+++ b/tests/regex_test.cpp
@@ -127,3 +127,24 @@ TEST(RegexTest, RegexReplace2) {
     EXPECT_EQ(true, replaced);
     EXPECT_STREQ("        true, true);", res.c_str());
 }
+
+TEST(RegexTest, RegexReplaceNoCopy) {
+    regex_code RE_PATTERN_CLEANSE_LINE_C_COMMENTS =
+        RegexCompile(
+            R"((\s*)" RE_PATTERN_C_COMMENTS R"(\s*$|)"
+            RE_PATTERN_C_COMMENTS R"(\s+|)"
+            R"(\s+)" RE_PATTERN_C_COMMENTS R"((?=\W)|)"
+            RE_PATTERN_C_COMMENTS ")");
+
+    bool replaced;
+    std::string res = "        /*foo=*/true, /*bar=*/true);";
+    RegexReplace(RE_PATTERN_CLEANSE_LINE_C_COMMENTS, "",
+                 &res, &replaced);
+    EXPECT_EQ(true, replaced);
+    EXPECT_STREQ("        true, true);", res.c_str());
+}
+
+TEST(RegexTest, RegexMatchWithRange) {
+    bool match = RegexMatchWithRange("^test$", "rangetest", 5, 4);
+    EXPECT_EQ(true, match);
+}

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -46,6 +46,24 @@ TEST(StringTest, StrStripWithChar) {
     EXPECT_STREQ("test", res.c_str());
 }
 
+TEST(StringTest, StrStripCharPointers) {
+    std::string input = "   test   ";
+    std::string res = StrStrip(&input[0], &input[input.size() - 1]);
+    EXPECT_STREQ("test", res.c_str());
+}
+
+TEST(StringTest, StrStripCharPointersEmpty) {
+    std::string input = "   ";
+    std::string res = StrStrip(&input[0], &input[input.size() - 1]);
+    EXPECT_STREQ("", res.c_str());
+}
+
+TEST(StringTest, StrStripCharPointersNostrip) {
+    std::string input = "a";
+    std::string res = StrStrip(&input[0], &input[input.size() - 1]);
+    EXPECT_STREQ("a", res.c_str());
+}
+
 TEST(StringTest, StrLstrip) {
     std::string res = StrLstrip("   test   ");
     EXPECT_STREQ("test   ", res.c_str());
@@ -141,7 +159,7 @@ TEST(StringTest, ParseCommaSeparetedList) {
         { "a", "b", "see", "d"};
     std::set<std::string> actual =
         ParseCommaSeparetedList("a,b, see ,,d");
-    EXPECT_EQ(expected.size(), actual.size());
+    ASSERT_EQ(expected.size(), actual.size());
     auto ex_it = expected.begin();
     auto ac_it = actual.begin();
     while (ex_it != expected.end()) {

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -134,6 +134,11 @@ TEST(StringTest, StrSplitTwo) {
     }
 }
 
+TEST(StringTest, StrSplitLast) {
+    std::string res = StrSplitLast("test foo bar");
+    EXPECT_STREQ("bar", res.c_str());
+}
+
 TEST(StringTest, StrSplitBy) {
     const std::vector<std::string> expected =
         { "test", "foo", "bar" };


### PR DESCRIPTION
- Added JIT compiler for some regex patterns on Windows and Linux. (6d8281bbdf0e938bce0ae349a845060fd4f1199a)
  JIT is disabled on macOS.
- Added thread local buffers for outputs to avoid mutex locks. (5f9b93dc9cecefc7bb7eab67ef84ab2384089e63)
- Fixed a path to googletest in `benchmark.yml`. (ed295c45391e305ba87ef69c4001b1dfb36b7db9)
- Added scripts to measure memory usage in `benchmark.yml`. (5e0d74b6ad0e548564c6dac2e62fe151120bad59)
- Added `--threads=` option to specify the number of threads for multithreading. (66f8a3e181feb1fa7db25f18798b6f8dffa1ef29)
- Parse filter strings when reading options. (efe1ab3e60140f8dd735d24358abc2b53e118465)
- Other minor changes for optimization.

Performance has improved dramatically with stderr buffering and the JIT compiler. You can see `cpplint-cpp` has significantly better performance, being over 30 times faster than `cpplint.py`.

**Execution time**

|             | googletest-1.14.0 (s) | cpplint-cpp (s) |
| ----------- | --------------------- | --------------- |
| cpplint-cpp | 0.530342              | 0.106502        |
| cpplint.py  | 25.555369             | 3.526787        |

**Memory usage**

|             | googletest-1.14.0 | cpplint-cpp |
| ----------- | ----------------- | ----------- |
| cpplint-cpp | 15.61 MiB         | 10.07 MiB   |
| cpplint.py  | 22.98 MiB         | 22.20 MiB   |
