### PR TITLE
v0.2.1 update (pip support)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.gitignore
+.vscode
+batch_files
+build*
+coverage-report
+dist
+Dockerfile
+python*

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,12 +16,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Build linux package for x86_64
+      - name: Install Meson
+        run: pip3 install meson ninja
+
+      - name: Build cpplint-cpp
         run: |
-          docker build -t cpplint ./
-          docker run --name cpplint cpplint
-          docker cp cpplint:/cpplint-cpp/dist ./
-          docker cp cpplint:/cpplint-cpp/subprojects ./
+          meson setup build --native-file=presets/release.ini
+          meson compile -C build
 
       - name: Copy gooletest, Download cpplint.py
         run: |
@@ -31,16 +32,19 @@ jobs:
       - name: Show CPU info
         run: |
           lscpu
-          ./dist/cpplint-cpp --threads=
+          ./build/cpplint-cpp --threads=
 
       - name: Lint cpplint-cpp
         run: |
-          python benchmark.py . --cpplint_cpp="./dist/cpplint-cpp"
+          python benchmark.py . --cpplint_cpp="./build/cpplint-cpp"
           sh memory_usage.sh "python cpplint.py" .
-          sh memory_usage.sh "./dist/cpplint-cpp" .
+          sh memory_usage.sh "./build/cpplint-cpp" .
 
       - name: Lint googletest
         run: |
-          python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./dist/cpplint-cpp"
+          python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./build/cpplint-cpp"
           sh memory_usage.sh "python cpplint.py" ../googletest-${{ env.GTEST_VER }}
-          sh memory_usage.sh "./dist/cpplint-cpp" ../googletest-${{ env.GTEST_VER }}
+          sh memory_usage.sh "./build/cpplint-cpp" ../googletest-${{ env.GTEST_VER }}
+
+      - name: Check required GLIBC version
+        run: bash .github/workflows/check_glibc_compatibility.sh ./build/cpplint-cpp

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,13 +16,12 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Meson
-        run: pip3 install meson ninja
-
-      - name: Build cpplint-cpp
+      - name: Build linux package for x86_64
         run: |
-          meson setup build --native-file=presets/release.ini
-          meson compile -C build
+          docker build -t cpplint ./
+          docker run --name cpplint cpplint
+          docker cp cpplint:/cpplint-cpp/dist ./
+          docker cp cpplint:/cpplint-cpp/subprojects ./
 
       - name: Copy gooletest, Download cpplint.py
         run: |
@@ -32,16 +31,16 @@ jobs:
       - name: Show CPU info
         run: |
           lscpu
-          ./build/cpplint-cpp --threads=
+          ./dist/cpplint-cpp --threads=
 
       - name: Lint cpplint-cpp
         run: |
-          python benchmark.py . --cpplint_cpp="./build/cpplint-cpp"
+          python benchmark.py . --cpplint_cpp="./dist/cpplint-cpp"
           sh memory_usage.sh "python cpplint.py" .
-          sh memory_usage.sh "./build/cpplint-cpp" .
+          sh memory_usage.sh "./dist/cpplint-cpp" .
 
       - name: Lint googletest
         run: |
-          python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./build/cpplint-cpp"
+          python benchmark.py ../googletest-${{ env.GTEST_VER }} --cpplint_cpp="./dist/cpplint-cpp"
           sh memory_usage.sh "python cpplint.py" ../googletest-${{ env.GTEST_VER }}
-          sh memory_usage.sh "./build/cpplint-cpp" ../googletest-${{ env.GTEST_VER }}
+          sh memory_usage.sh "./dist/cpplint-cpp" ../googletest-${{ env.GTEST_VER }}

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -1,0 +1,97 @@
+name: Build wheel packages
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.check-tag.outputs.tag }}
+    steps:
+      - name: Check tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.ref }} == refs/tags/v* ]]; then
+            TAG=$(echo ${{ github.ref }} | sed -e "s#refs/tags/##g")
+          else
+            TAG=$(echo ${{ github.sha }} | cut -c1-7)
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - uses: actions/checkout@v4
+
+      - name: Create Release Draft
+        id: create-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.check-tag.outputs.tag }}
+          name: ${{ steps.check-tag.outputs.tag }}
+          body: |
+            ## Changelog
+
+            - First Change
+            - Second Change
+          draft: true
+          prerelease: false
+
+  build:
+    name: build-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, ubuntu-20.04, macos-14]
+    runs-on: ${{ matrix.os }}
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Meson for Windows
+        if: runner.os == 'Windows'
+        run: pip install meson
+
+      - name: Install Meson for Unix
+        if: runner.os != 'Windows'
+        run: pip3 install meson ninja
+
+      - name: Prepare MSVC
+        if: runner.os == 'Windows'
+        uses: bus1/cabuild/action/msdevshell@v1
+        with:
+          architecture: x64
+
+      - name: Build c++ binary
+        run: |
+          meson setup build --native-file=presets/release.ini
+          meson compile -C build
+          meson test -C build -v
+
+      - name: Copy built binary
+        run: |
+          mkdir dist
+          $(cp build/cpplint-cpp dist 2>/dev/null || exit 0)
+          $(cp build/cpplint-cpp.exe dist 2>/dev/null || exit 0)
+        shell: bash
+
+      - name: Build wheel package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Check required GLIBC version
+        if: runner.os == 'Linux'
+        run: bash .github/workflows/check_glibc_compatibility.sh ./build/cpplint-cpp
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.setup.outputs.tag }} dist/*.whl
+        shell: bash

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: setup
     steps:
       - uses: actions/checkout@v4
@@ -100,8 +100,13 @@ jobs:
           gh release upload ${{ needs.setup.outputs.tag }} dist/*.whl
         shell: bash
 
-  build-macos:
-    runs-on: macos-latest
+  build-unix:
+    name: build-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     needs: setup
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +122,18 @@ jobs:
           meson setup build --native-file=presets/release.ini
           meson compile -C build
           meson test -C build -v
-          strip ./build/cpplint-cpp
+
+      - name: Check required GLIBC version
+        if: runner.os == 'Linux'
+        run: bash .github/workflows/check_glibc_compatibility.sh ./build/cpplint-cpp
+
+      - name: Strip symbols
+        if: matrix.os == 'Linux'
+        run: strip --strip-all ./build/cpplint-cpp
+
+      - name: Strip symbols
+        if: matrix.os != 'Linux'
+        run: strip ./build/cpplint-cpp
 
       - name: Copy built binary
         run: |

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -39,13 +39,13 @@ jobs:
           draft: true
           prerelease: false
 
-  build:
-    name: build-${{ matrix.os }}
+  build-windows:
+    name: build-windows_${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-14]
-    runs-on: ${{ matrix.os }}
+        arch: [amd64, arm64]
+    runs-on: windows-latest
     needs: setup
     steps:
       - uses: actions/checkout@v4
@@ -53,31 +53,33 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Meson for Windows
-        if: runner.os == 'Windows'
+      - name: Install Meson
         run: pip install meson
 
-      - name: Install Meson for Unix
-        if: runner.os != 'Windows'
-        run: pip3 install meson ninja
-
       - name: Prepare MSVC
-        if: runner.os == 'Windows'
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           architecture: x64
 
-      - name: Build c++ binary
+      - name: Build c++ binary for arm64
+        if: matrix.arch == 'amd64'
         run: |
           meson setup build --native-file=presets/release.ini
+          meson compile -C build
+          meson test -C build -v
+
+      - name: Build c++ binary for arm64
+        if: matrix.arch == 'arm64'
+        run: |
+          meson setup build --cross-file=presets/release.ini --cross-file=presets/windows_arm64.ini
           meson compile -C build
           meson test -C build -v
 
       - name: Copy built binary
         run: |
           mkdir dist
-          $(cp build/cpplint-cpp dist 2>/dev/null || exit 0)
-          $(cp build/cpplint-cpp.exe dist 2>/dev/null || exit 0)
+          cp build/cpplint-cpp.exe dist
+          cp build/version.h dist
         shell: bash
 
       - name: Build wheel package
@@ -85,9 +87,80 @@ jobs:
           pip install build
           python -m build
 
-      - name: Check required GLIBC version
-        if: runner.os == 'Linux'
-        run: bash .github/workflows/check_glibc_compatibility.sh ./build/cpplint-cpp
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.setup.outputs.tag }} dist/*.whl
+        shell: bash
+
+  build-macos:
+    runs-on: macos-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Meson for Unix
+        run: pip3 install meson ninja
+
+      - name: Build c++ binary
+        run: |
+          meson setup build --native-file=presets/release.ini
+          meson compile -C build
+          meson test -C build -v
+          strip ./build/cpplint-cpp
+
+      - name: Copy built binary
+        run: |
+          mkdir dist
+          cp build/cpplint-cpp dist
+          cp build/version.h dist
+
+      - name: Build wheel package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.setup.outputs.tag }} dist/*.whl
+        shell: bash
+
+  build-linux_arm64:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build linux package for arm64
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          docker buildx build --platform linux/arm64 -t cpplint_arm ./
+          docker run --name cpplint_arm cpplint_arm
+          docker cp cpplint_arm:/cpplint-cpp/dist ./
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.setup.outputs.tag }} dist/*.whl
+        shell: bash
+
+  build-linux_x86_64:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build linux package for x86_64
+        run: |
+          docker build -t cpplint ./
+          docker run --name cpplint cpplint
+          docker cp cpplint:/cpplint-cpp/dist ./
 
       - name: Upload Release Asset
         env:

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -36,6 +36,12 @@ jobs:
 
             - First Change
             - Second Change
+
+            ## Installation
+
+            ```sh
+            pip install cpplint-cpp --find-links https://github.com/matyalatte/cpplint-cpp/releases/tag/${{ steps.check-tag.outputs.tag }}
+            ```
           draft: true
           prerelease: false
 

--- a/.github/workflows/check_glibc_compatibility.sh
+++ b/.github/workflows/check_glibc_compatibility.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Checks required versions of GLIBC and GLIBCXX.
+# bash ./check_glibc_compatibility.sh path/to/your/binary
+
+glibc_deps=$(objdump -T $1 | grep GLIBC_ | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu)
+glibcxx_deps=$(objdump -T $1 | grep GLIBCXX_ | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu)
+IFS=''
+if [ "${glibc_deps}" != "" ]; then
+    echo Required GLIBC versions;
+    echo $glibc_deps
+fi
+if [ "${glibcxx_deps}" != "" ]; then
+    echo Required GLIBCXX versions;
+    echo $glibcxx_deps
+fi
+if [ "${glibc_deps}" == "" ] && [ "${glibcxx_deps}" == "" ]; then
+    echo No GLIBC dependencies.
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Meson for Windows
         if: runner.os == 'Windows'
@@ -60,3 +60,7 @@ jobs:
           meson setup build
           meson compile -C build
           meson test -C build -v
+
+      - name: Check required GLIBC version
+        if: runner.os == 'Linux'
+        run: bash .github/workflows/check_glibc_compatibility.sh ./build/cpplint-cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-14]
+        os: [windows-2022, ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 build*
+!build*.yml
 *.exe
 *.bat
 *.sh
 !memory_usage.sh
+!check_glibc_compatibility.sh
 *.txt
 !meson_options.txt
 
@@ -18,7 +20,12 @@ coverage-report
 # python
 *.py
 !benchmark.py
+!setup.py
 python*
+dist
+*.egg-info
+*.whl
+*.tar.gz
 
 # vscode
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build*
 !build*.yml
+cpplint-cpp
 *.exe
 *.bat
 *.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Building workflow for musl build.
+#
+# 1. Use this docker file to build the executable.
+#    docker build -t cpplint ./
+#
+# 2. Run the built image.
+#    docker run --name cpplint cpplint
+#
+# 3. Use "docker cp" to get the built executable.
+#    docker cp cpplint:/cpplint-cpp/dist ./
+#
+# Notes:
+#   -You can use buildx for cross compiling
+#    sudo apt install -y qemu-user-static binfmt-support
+#    docker buildx build --platform linux/arm64 -t cpplint_arm ./
+
+# Base image
+FROM alpine:3.18.8
+
+# Install packages
+RUN apk update && \
+    apk add --no-cache \
+        alpine-sdk linux-headers bash \
+        py3-pip python3
+
+# Install meson
+RUN pip3 install meson==1.3.1 ninja==1.11.1 build
+
+# Clone the repo
+COPY . /cpplint-cpp
+
+# Build
+WORKDIR /cpplint-cpp
+RUN meson setup build --native-file=presets/release.ini && \
+    meson compile -C build && \
+    meson test -C build && \
+    strip --strip-all ./build/cpplint-cpp
+
+# Make wheel package
+WORKDIR /cpplint-cpp
+RUN mkdir dist && \
+    cp ./build/cpplint-cpp dist && \
+    cp ./build/version.h dist && \
+    python3 -m build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
 include dist
+include dist/version.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+include dist

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ You can see `cpplint-cpp` has significantly better performance, being over 30 ti
 
 |             | googletest-1.14.0 (s) | cpplint-cpp (s) |
 | ----------- | --------------------- | --------------- |
-| cpplint-cpp | 0.530342              | 0.106502        |
-| cpplint.py  | 25.555369             | 3.526787        |
+| cpplint-cpp | 0.443100              | 0.090062        |
+| cpplint.py  | 25.826862             | 3.865572        |
 
 ### Memory usage
 
@@ -38,8 +38,8 @@ Despite using multithreading with 4 cores, `cpplint-cpp` has lower memory usage 
 
 |             | googletest-1.14.0 | cpplint-cpp |
 | ----------- | ----------------- | ----------- |
-| cpplint-cpp | 15.61 MiB         | 10.07 MiB   |
-| cpplint.py  | 22.98 MiB         | 22.20 MiB   |
+| cpplint-cpp | 15.55 MiB         | 10.32 MiB   |
+| cpplint.py  | 23.01 MiB         | 22.43 MiB   |
 
 ## Changes from cpplint.py
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ C++ reimplementation of [cpplint 1.7](https://github.com/cpplint/cpplint/tree/ab
 [Cpplint](https://github.com/cpplint/cpplint) is a command-line tool to check C/C++ files for style issues according to [Google's C++ style guide](http://google.github.io/styleguide/cppguide.html).
 It used to be developed and maintained by Google Inc. One of its forks now maintains the project.
 
+## Installation
+
+You can install the `cpplint-cpp` command via pip.
+
+```sh
+pip install cpplint-cpp --find-links https://github.com/matyalatte/cpplint-cpp/releases/latest
+```
+
 ## cpplint-cpp vs. cpplint.py
 
 Here is an analysis of the performance differences between `cpplint-cpp` and `cpplint.py` against two repositories:
@@ -53,12 +61,8 @@ cpplint-cpp is a WIP project. Please note that the following features are not im
 - JUnit style outputs.
 - Multibyte characters in stdin on Windows.
 - UNIX convention of using "-" for stdin.
-- Installation by package managers.
 
 ## Building
-
-> [!Warning]
-> There is no installers yet. You need to build cpplint-cpp from the source and setup the environment by yourself.
 
 ### Requirements
 
@@ -73,7 +77,7 @@ You can build `cpplint-cpp` with the following commands.
 meson setup build
 meson compile -C build
 meson test -C build
-./build/cpplint-cpp --recursive .
+./build/cpplint-cpp --version
 ```
 
 ### Release build
@@ -83,6 +87,18 @@ You can use [`presets/release.ini`](./presets/release.ini) to enable options for
 ```sh
 meson setup build --native-file=presets/release.ini
 meson compile -C build
+```
+
+### Build wheel package
+
+You can make a pip package with the following commands.
+
+```sh
+mkdir dist
+cp ./build/cpplint-cpp ./dist
+cp ./build/version.h ./dist
+pip install build
+python -m build
 ```
 
 ## Submitting Feature Requests

--- a/include/common.h
+++ b/include/common.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cctype>
 #include <string>
 
 // You can suppress warnings about unused variables with this macro.
@@ -22,3 +23,7 @@ static_assert(std::string::npos == static_cast<size_t>(-1),
 
 // Maximum valid value
 constexpr size_t INDEX_MAX = SIZE_MAX - 1;
+
+// Macros for characters
+#define IS_SPACE(c) isspace((uint8_t)(c))
+#define IS_DIGIT(c) isdigit((uint8_t)(c))

--- a/include/cpplint_state.h
+++ b/include/cpplint_state.h
@@ -124,6 +124,9 @@ class CppLintState {
     // Flush buffers for cout and cerr
     void FlushThreadStream();
 
+    // Get error buffer as string
+    std::string GetErrorStreamAsStr();
+
     // Print a summary of errors by category, and the total.
     void PrintErrorCounts();
     void PrintInfo(const std::string& message);

--- a/include/file_linter.h
+++ b/include/file_linter.h
@@ -25,6 +25,7 @@ class FileLinter {
     std::string m_filename;
     std::string m_file_extension;
     fs::path m_file_from_repo;  // relative path from repository
+    std::string m_basefilename_relative;
     std::string m_cppvar;
     regex_match m_re_result;
     bool m_has_error;
@@ -42,6 +43,7 @@ class FileLinter {
                 m_filename(file.string()),
                 m_file_extension(),
                 m_file_from_repo(),
+                m_basefilename_relative(),
                 m_cppvar(),
                 m_re_result(RegexCreateMatchData(16)),
                 m_has_error(false) {}
@@ -236,7 +238,7 @@ class FileLinter {
     // Returns true if an error was emitted. false otherwise.
     bool CheckCStyleCast(const CleansedLines& clean_lines,
                          const std::string& elided_line, size_t linenum,
-                         const std::string& cast_type,
+                         const char* cast_type,
                          const regex_code& pattern);
 
     // Various cast related checks.

--- a/include/getline.h
+++ b/include/getline.h
@@ -18,7 +18,7 @@ enum LineStatus : int {
  * @param stream An istream object. (e.g., std::cin, std::ifstream)
  * @returns Bitwise OR of LineStatus values.
  */
-std::string GetLine(std::istream& stream, int* status);
+std::string GetLine(std::istream& stream, std::string* buffer, int* status);
 
 // Gets the number of characters in a line that was read with GetLine().
 // It might crash when the line has broken bytes.

--- a/include/options.h
+++ b/include/options.h
@@ -108,7 +108,6 @@ class Options {
 
     std::set<std::string> GetAllExtensions() const;
     std::set<std::string> GetHeaderExtensions() const;
-    std::set<std::string> GetNonHeaderExtensions() const;
 
     bool ProcessConfigOverrides(const fs::path& filename,
                                 CppLintState* cpplint_state);

--- a/include/options.h
+++ b/include/options.h
@@ -107,8 +107,6 @@ class Options {
     size_t LineLength() const { return m_line_length; }
 
     std::set<std::string> GetAllExtensions() const;
-    bool IsHeaderExtension(const std::string& file_extension) const;
-    bool IsSourceExtension(const std::string& file_extension) const;
     std::set<std::string> GetHeaderExtensions() const;
     std::set<std::string> GetNonHeaderExtensions() const;
 

--- a/include/regex_utils.h
+++ b/include/regex_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #ifndef PCRE2_STATIC
@@ -40,6 +41,9 @@ inline constexpr uint32_t REGEX_FLAGS_DEFAULT = 0;
 // std::smatch.str(i) for pcre2
 std::string GetMatchStr(regex_match& match, const std::string &subject, int i,
                         size_t startoffset = 0);
+
+std::string_view GetMatchStrView(regex_match& match, const std::string &subject, int i,
+                                 size_t startoffset = 0);
 
 // std::smatch[i].matched
 bool IsMatched(regex_match& match, int i) noexcept;

--- a/include/regex_utils.h
+++ b/include/regex_utils.h
@@ -38,11 +38,15 @@ inline constexpr uint32_t REGEX_OPTIONS_MULTILINE = PCRE2_MULTILINE | REGEX_OPTI
 
 inline constexpr uint32_t REGEX_FLAGS_DEFAULT = 0;
 
+// Note: Templated functions with "typename STR" should support std::string and std::string_view.
+
 // std::smatch.str(i) for pcre2
-std::string GetMatchStr(regex_match& match, const std::string &subject, int i,
+template <typename STR>
+std::string GetMatchStr(regex_match& match, const STR&subject, int i,
                         size_t startoffset = 0);
 
-std::string_view GetMatchStrView(regex_match& match, const std::string &subject, int i,
+template <typename STR>
+std::string_view GetMatchStrView(regex_match& match, const STR&subject, int i,
                                  size_t startoffset = 0);
 
 // std::smatch[i].matched
@@ -86,23 +90,27 @@ inline regex_match RegexCreateMatchData(const regex_code& regex) noexcept {
     return regex_match(ret);
 }
 
-bool RegexSearch(const regex_code& regex, const std::string& str,
+template <typename STR>
+bool RegexSearch(const regex_code& regex, const STR& str,
                  uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 
-bool RegexSearch(const regex_code& regex, const std::string& str,
+template <typename STR>
+bool RegexSearch(const regex_code& regex, const STR& str,
                  regex_match& result,
                  uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 
+template <typename STR>
 inline bool RegexSearch(
-        const std::string& regex, const std::string& str,
+        const std::string& regex, const STR& str,
         uint32_t options = REGEX_OPTIONS_DEFAULT,
         uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
     regex_code re = RegexCompile(regex, options);
     return RegexSearch(re, str, flags);
 }
 
+template <typename STR>
 inline bool RegexSearch(
-        const std::string& regex, const std::string& str,
+        const std::string& regex, const STR& str,
         regex_match& result,
         uint32_t options = REGEX_OPTIONS_DEFAULT,
         uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
@@ -112,17 +120,20 @@ inline bool RegexSearch(
 
 // RegexSearch(regex, str.substr(startoffset, length))
 // without creating string objects for substr
-bool RegexSearchWithRange(const regex_code& regex, const std::string& str,
+template <typename STR>
+bool RegexSearchWithRange(const regex_code& regex, const STR& str,
                           size_t startoffset, size_t length,
                           uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 
-bool RegexSearchWithRange(const regex_code& regex, const std::string& str,
+template <typename STR>
+bool RegexSearchWithRange(const regex_code& regex, const STR& str,
                           size_t startoffset, size_t length,
                           regex_match& result,
                           uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 
+template <typename STR>
 inline bool RegexSearchWithRange(
-        const std::string& regex, const std::string& str,
+        const std::string& regex, const STR& str,
         size_t startoffset, size_t length,
         uint32_t options = REGEX_OPTIONS_DEFAULT,
         uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
@@ -130,8 +141,9 @@ inline bool RegexSearchWithRange(
     return RegexSearchWithRange(re, str, startoffset, length, flags);
 }
 
+template <typename STR>
 inline bool RegexSearchWithRange(
-        const std::string& regex, const std::string& str,
+        const std::string& regex, const STR& str,
         size_t startoffset, size_t length,
         regex_match& result,
         uint32_t options = REGEX_OPTIONS_DEFAULT,
@@ -140,25 +152,29 @@ inline bool RegexSearchWithRange(
     return RegexSearchWithRange(re, str, startoffset, length, result, flags);
 }
 
-inline bool RegexMatch(const std::string& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatch(const std::string& regex, const STR& str,
                        uint32_t options = REGEX_OPTIONS_DEFAULT,
                        uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
     return RegexSearch(regex, str, options, flags | PCRE2_ANCHORED);
 }
 
-inline bool RegexMatch(const regex_code& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatch(const regex_code& regex, const STR& str,
                        uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
     return RegexSearch(regex, str, flags | PCRE2_ANCHORED);
 }
 
-inline bool RegexMatch(const std::string& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatch(const std::string& regex, const STR& str,
                        regex_match& result,
                        uint32_t options = REGEX_OPTIONS_DEFAULT,
                        uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
     return RegexSearch(regex, str, result, options, flags | PCRE2_ANCHORED);
 }
 
-inline bool RegexMatch(const regex_code& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatch(const regex_code& regex, const STR& str,
                        regex_match& result,
                        uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
     return RegexSearch(regex, str, result, flags | PCRE2_ANCHORED);
@@ -166,14 +182,16 @@ inline bool RegexMatch(const regex_code& regex, const std::string& str,
 
 // RegexMatch(regex, str.substr(startoffset, length))
 // without creating string objects for substr
-inline bool RegexMatchWithRange(const regex_code& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatchWithRange(const regex_code& regex, const STR& str,
                                 size_t startoffset, size_t length,
                                 uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
     return RegexSearchWithRange(regex, str, startoffset, length,
                                 flags | PCRE2_ANCHORED);
 }
 
-inline bool RegexMatchWithRange(const regex_code& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatchWithRange(const regex_code& regex, const STR& str,
                                 size_t startoffset, size_t length,
                                 regex_match& result,
                                 uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
@@ -181,7 +199,8 @@ inline bool RegexMatchWithRange(const regex_code& regex, const std::string& str,
                                 result, flags | PCRE2_ANCHORED);
 }
 
-inline bool RegexMatchWithRange(const std::string& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatchWithRange(const std::string& regex, const STR& str,
                                 size_t startoffset, size_t length,
                                 uint32_t options = REGEX_OPTIONS_DEFAULT,
                                 uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept {
@@ -189,7 +208,8 @@ inline bool RegexMatchWithRange(const std::string& regex, const std::string& str
                                 options, flags | PCRE2_ANCHORED);
 }
 
-inline bool RegexMatchWithRange(const std::string& regex, const std::string& str,
+template <typename STR>
+inline bool RegexMatchWithRange(const std::string& regex, const STR& str,
                                 size_t startoffset, size_t length,
                                 regex_match& result,
                                 uint32_t options = REGEX_OPTIONS_DEFAULT,
@@ -240,6 +260,10 @@ inline void RegexReplace(const regex_code& regex, const std::string& fmt,
 
 std::string RegexEscape(const std::string& str);
 
+inline std::string RegexEscape(const std::string_view& str) {
+    return RegexEscape(std::string(str));
+}
+
 // Split a string by a regex pattern.
 std::vector<std::string> RegexSplit(const std::string& regex, const std::string& str);
 
@@ -256,10 +280,12 @@ inline regex_code RegexJitCompile(const std::string& regex,
 
 // This function is 10% faster than RegexSearch
 // but it crashes when regex_code is not JIT compiled.
-bool RegexJitSearch(const regex_code& regex, const std::string& str,
+template <typename STR>
+bool RegexJitSearch(const regex_code& regex, const STR& str,
                     uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 
-bool RegexJitSearch(const regex_code& regex, const std::string& str,
+template <typename STR>
+bool RegexJitSearch(const regex_code& regex, const STR& str,
                     regex_match& result,
                     uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 

--- a/include/regex_utils.h
+++ b/include/regex_utils.h
@@ -55,14 +55,19 @@ PCRE2_SIZE GetMatchEnd(regex_match& match, int i,
 // std::smatch.str(i).size()
 PCRE2_SIZE GetMatchSize(regex_match& match, int i) noexcept;
 
-pcre2_code* RegexCompileBase(const std::string& regex,
+pcre2_code* RegexCompileBase(const char* regex,
                              uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept;
 
 // get pcre2_code as a unique pointer
-inline regex_code RegexCompile(const std::string& regex,
+inline regex_code RegexCompile(const char* regex,
                                uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept {
     pcre2_code* ret = RegexCompileBase(regex, options);
     return regex_code(ret);
+}
+
+inline regex_code RegexCompile(const std::string& regex,
+                               uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept {
+    return RegexCompile(regex.c_str(), options);
 }
 
 // ovecsize is the number of groups plus one.
@@ -206,15 +211,27 @@ inline std::string RegexReplace(const std::string& regex, const std::string& fmt
 }
 
 // This version is faster than others but strings should be mutable.
-void RegexReplace(const regex_code& regex, const std::string& fmt,
+void RegexReplace(const regex_code& regex, const char* fmt,
                   std::string* str,
                   bool* replaced, bool replace_all = true);
 
 inline void RegexReplace(const regex_code& regex, const std::string& fmt,
                          std::string* str,
+                         bool* replaced, bool replace_all = true) {
+    RegexReplace(regex, fmt.c_str(), str, replaced, replace_all);
+}
+
+inline void RegexReplace(const regex_code& regex, const char* fmt,
+                         std::string* str,
                          bool replace_all = true) {
     bool replaced = false;
     RegexReplace(regex, fmt, str, &replaced, replace_all);
+}
+
+inline void RegexReplace(const regex_code& regex, const std::string& fmt,
+                         std::string* str,
+                         bool replace_all = true) {
+    RegexReplace(regex, fmt.c_str(), str, replace_all);
 }
 
 std::string RegexEscape(const std::string& str);
@@ -225,8 +242,13 @@ std::vector<std::string> RegexSplit(const std::string& regex, const std::string&
 #ifdef SUPPORT_JIT
 // Uses jit compiler for regex
 // It makes matching faster when using complex patterns in RegexSearch.
-regex_code RegexJitCompile(const std::string& regex,
+regex_code RegexJitCompile(const char* regex,
                            uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept;
+
+inline regex_code RegexJitCompile(const std::string& regex,
+                                  uint32_t options = REGEX_OPTIONS_DEFAULT) noexcept {
+    return RegexJitCompile(regex.c_str(), options);
+}
 
 // This function is 10% faster than RegexSearch
 // but it crashes when regex_code is not JIT compiled.
@@ -237,11 +259,11 @@ bool RegexJitSearch(const regex_code& regex, const std::string& str,
                     regex_match& result,
                     uint32_t flags = REGEX_FLAGS_DEFAULT) noexcept;
 
-void RegexJitReplace(const regex_code& regex, const std::string& fmt,
+void RegexJitReplace(const regex_code& regex, const char* fmt,
                     std::string* str,
                     bool* replaced, bool replace_all = true);
 
-inline void RegexJitReplace(const regex_code& regex, const std::string& fmt,
+inline void RegexJitReplace(const regex_code& regex, const char* fmt,
                             std::string* str,
                             bool replace_all = true) {
     bool replaced = false;

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 #include "common.h"
 
@@ -81,6 +82,15 @@ inline bool InCharVec(const std::vector<char>& char_vec, const std::string& str)
     return false;
 }
 
+inline bool InCharVec(const std::vector<char>& char_vec, const std::string_view& str) {
+    if (str.size() != 1) return false;
+    for (char c : char_vec) {
+        if (str[0] == c)
+            return true;
+    }
+    return false;
+}
+
 inline bool StrContain(const std::string& str, const std::string& target) {
     return str.find(target) != std::string::npos;
 }
@@ -98,6 +108,10 @@ inline bool StrContain(const std::string& str, const char c, size_t pos) {
 }
 
 inline bool StrIsChar(const std::string& str, char c) {
+    return str.size() == 1 && str[0] == c;
+}
+
+inline bool StrIsChar(const std::string_view& str, char c) {
     return str.size() == 1 && str[0] == c;
 }
 
@@ -141,3 +155,4 @@ size_t GetLastNonSpacePos(const std::string& str) noexcept;
 
 // Returns true if the string consists of only digits.
 bool StrIsDigit(const std::string& str) noexcept;
+bool StrIsDigit(const std::string_view& str) noexcept;

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -149,3 +149,7 @@ size_t GetLastNonSpacePos(const std::string& str) noexcept;
 // Returns true if the string consists of only digits.
 bool StrIsDigit(const std::string& str) noexcept;
 bool StrIsDigit(const std::string_view& str) noexcept;
+
+// Remove items of set2 from set1.
+std::set<std::string> SetDiff(const std::set<std::string>& set1,
+                              const std::set<std::string>& set2);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -121,6 +121,7 @@ std::string StrToLower(const std::string &str);
 std::string StrToUpper(const std::string &str);
 
 // Returns the first non-space character or a null terminator.
+// You can replace RegexMatch(R"(\s*x)", line) with GetFirstNoneSpace(line) == 'x'
 char GetFirstNonSpace(const std::string& str, size_t pos = 0) noexcept;
 
 // Returns index to the first non-space character or INDEX_NONE.
@@ -132,7 +133,11 @@ inline bool StrIsBlank(const std::string& str) noexcept {
 }
 
 // Returns the last non-space character or a null terminator.
-char GetLastNonSpace(const std::string& str, size_t pos = 0) noexcept;
+// You can replace RegexSearch(R"(x\s*$)", line) with GetLastNoneSpace(line) == 'x'
+char GetLastNonSpace(const std::string& str) noexcept;
+
+// Returns index to the last non-space character or INDEX_NONE.
+size_t GetLastNonSpacePos(const std::string& str) noexcept;
 
 // Returns true if the string consists of only digits.
 bool StrIsDigit(const std::string& str) noexcept;

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -39,13 +39,15 @@ size_t StrLstripSize(const std::string &str);
 std::vector<std::string> StrSplit(const std::string& str, size_t max_size = INDEX_MAX);
 
 // StrSplit().back()
-std::string StrSplitLast(const std::string& str);
+template <typename STR>
+STR StrSplitLast(const STR& str);
 
 // Split string by another string.
 std::vector<std::string> StrSplitBy(const std::string &str, const std::string &delimiter);
 
 // Split string by comma, strip white spaces, and remove duplicated items.
-std::set<std::string> ParseCommaSeparetedList(const std::string& str);
+template <typename STR>
+std::set<std::string> ParseCommaSeparetedList(const STR& str);
 
 // Concat vec2 to vec1.
 template <typename T>
@@ -54,7 +56,8 @@ inline void ConcatVec(std::vector<T>& vec1, std::vector<T>& vec2) {
 }
 
 // Check if a string is in a vector of strings
-inline bool InStrVec(const std::vector<std::string>& str_vec, const std::string& str) {
+template <typename STR>
+inline bool InStrVec(const std::vector<std::string>& str_vec, const STR& str) {
     for (const std::string& s : str_vec) {
         if (s == str)
             return true;
@@ -63,7 +66,8 @@ inline bool InStrVec(const std::vector<std::string>& str_vec, const std::string&
 }
 
 // You can also use a null terminated array of char* instead of vector.
-inline bool InStrVec(const char* const *str_vec, const std::string& str) {
+template <typename STR>
+inline bool InStrVec(const char* const *str_vec, const STR& str) {
     while (*str_vec != nullptr) {
         if (str == *str_vec)
             return true;
@@ -73,16 +77,8 @@ inline bool InStrVec(const char* const *str_vec, const std::string& str) {
 }
 
 // Check if a character is in a vector of strings
-inline bool InCharVec(const std::vector<char>& char_vec, const std::string& str) {
-    if (str.size() != 1) return false;
-    for (char c : char_vec) {
-        if (str[0] == c)
-            return true;
-    }
-    return false;
-}
-
-inline bool InCharVec(const std::vector<char>& char_vec, const std::string_view& str) {
+template <typename STR>
+inline bool InCharVec(const std::vector<char>& char_vec, const STR& str) {
     if (str.size() != 1) return false;
     for (char c : char_vec) {
         if (str[0] == c)
@@ -107,11 +103,8 @@ inline bool StrContain(const std::string& str, const char c, size_t pos) {
     return str.find(c, pos) != std::string::npos;
 }
 
-inline bool StrIsChar(const std::string& str, char c) {
-    return str.size() == 1 && str[0] == c;
-}
-
-inline bool StrIsChar(const std::string_view& str, char c) {
+template <typename STR>
+inline bool StrIsChar(const STR& str, char c) {
     return str.size() == 1 && str[0] == c;
 }
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -81,14 +81,6 @@ inline bool InCharVec(const std::vector<char>& char_vec, const std::string& str)
     return false;
 }
 
-inline bool InStrSet(const std::set<std::string>& str_vec, const std::string& str) {
-    for (const std::string& s : str_vec) {
-        if (s == str)
-            return true;
-    }
-    return false;
-}
-
 inline bool StrContain(const std::string& str, const std::string& target) {
     return str.find(target) != std::string::npos;
 }

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -131,5 +131,8 @@ inline bool StrIsBlank(const std::string& str) noexcept {
     return GetFirstNonSpace(str) == '\0';
 }
 
+// Returns the last non-space character or a null terminator.
+char GetLastNonSpace(const std::string& str, size_t pos = 0) noexcept;
+
 // Returns true if the string consists of only digits.
 bool StrIsDigit(const std::string& str) noexcept;

--- a/meson.build
+++ b/meson.build
@@ -46,13 +46,14 @@ if cpplint_os == 'windows'
         # don't require shipping the MinGW-w64 DLLs
         cpplint_link_args += static_libc_args
     endif
-    if cpplint_cpu == 'aarch64'
-        cpplint_cpu = 'arm64'
+    arch = cpplint_cpu
+    if arch == 'aarch64'
+        arch = 'arm64'
     endif
-    if cpplint_cpu == 'x86_64'
-        cpplint_cpu = 'amd64'
+    if arch == 'x86_64'
+        arch = 'amd64'
     endif
-    cpplint_platform_tag = 'win_' + cpplint_cpu
+    cpplint_platform_tag = 'win_' + arch
 elif cpplint_os == 'darwin'
     # Set deployment targets
     languages = ['c', 'cpp']
@@ -75,10 +76,11 @@ elif cpplint_os == 'darwin'
         add_global_link_arguments(arch, language: languages)
         cpplint_platform_tag += '_universal2'
     else
-        if cpplint_cpu == 'aarch64'
-            cpplint_cpu = 'arm64'
+        arch = cpplint_cpu
+        if arch == 'aarch64'
+            arch = 'arm64'
         endif
-        cpplint_platform_tag += '_' + cpplint_cpu
+        cpplint_platform_tag += '_' + arch
         warning('Universal build is disabled since your SDKs do not support it.')
     endif
 elif cpplint_os == 'linux'
@@ -135,11 +137,14 @@ pcre2_jit_supported = (cpplint_cpu in cpu_jit_supported and
                        cpplint_compiler_id != 'tcc' and
                        cpplint_os != 'darwin')
 if pcre2_jit_supported
+    message('JIT compiler is enabled.')
     if cpplint_compiler_id == 'msvc'
         add_global_arguments('/DSUPPORT_JIT', language: ['c', 'cpp'])
     else
         add_global_arguments('-DSUPPORT_JIT', language: ['c', 'cpp'])
     endif
+else
+    message('JIT compiler is disabled on this platform.')
 endif
 
 # get pcre2

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project('cpplint-cpp', ['c', 'cpp'],
         'cpp_winlibs=',                 # likewise as with c_winlibs
         'wrap_mode=forcefallback'       # we don't use installed libraries.
     ],
-    version: '0.2.0')
+    version: '0.2.1')
 
 cpplint_link_args = []
 cpplint_c_args = []

--- a/meson.build
+++ b/meson.build
@@ -106,8 +106,8 @@ elif cpplint_os == 'linux'
         cpplint_platform_tag = 'linux_'
     else
         message('Use dynamic linked glibc.')
-        # requires glibc 2.29 or later
-        cpplint_platform_tag = 'manylinux_2_29_'
+        # requires glibc 2.34 or later when building on ubuntu 22.04
+        cpplint_platform_tag = 'manylinux_2_34_'
     endif
     cpplint_platform_tag += cpplint_cpu
 else

--- a/meson.build
+++ b/meson.build
@@ -17,12 +17,22 @@ project('cpplint-cpp', ['c', 'cpp'],
 cpplint_link_args = []
 cpplint_c_args = []
 cpplint_os = host_machine.system()
-cpplint_cpu = host_machine.cpu_family()
-cpplint_compiler = meson.get_compiler('c').get_id()
+cpplint_cpu = target_machine.cpu_family()
+cpplint_compiler = meson.get_compiler('c')
+cpplint_compiler_id = cpplint_compiler.get_id()
 cpplint_is_debug = get_option('buildtype').startswith('debug')
+cpplint_platform_tag = 'unknown'
 
+# Use this when linking static libc
+static_libc_args = [
+    '-static',
+    '-static-libgcc',
+    '-static-libstdc++',
+]
+
+# Get options
 if cpplint_os == 'windows'
-    if cpplint_compiler == 'msvc'
+    if cpplint_compiler_id == 'msvc'
         cpplint_link_args += [
             '/LARGEADDRESSAWARE',
             '/INCREMENTAL:NO'
@@ -33,13 +43,16 @@ if cpplint_os == 'windows'
             cpplint_link_args += ['/OPT:ICF', '/LTCG']
         endif
     else
-		# don't require shipping the MinGW-w64 DLLs
-		cpplint_link_args += [
-			'-static',
-			'-static-libgcc',
-			'-static-libstdc++',
-		]
-	endif
+        # don't require shipping the MinGW-w64 DLLs
+        cpplint_link_args += static_libc_args
+    endif
+    if (cpplint_cpu == 'aarch64')
+        cpplint_cpu = 'arm64'
+    endif
+    if (cpplint_cpu == 'x86_64')
+        cpplint_cpu = 'amd64'
+    endif
+    cpplint_platform_tag = 'win_' + cpplint_cpu
 elif cpplint_os == 'darwin'
     # Set deployment targets
     languages = ['c', 'cpp']
@@ -49,27 +62,80 @@ elif cpplint_os == 'darwin'
 
     # Check if SDKs support universal binaries or not.
     arch = ['-arch', 'x86_64', '-arch', 'arm64']
-    c_compiler = meson.get_compiler('c')
-    result = c_compiler.run(
+    result = cpplint_compiler.run(
         'int main(void) { return 0; }',
         name : 'universal binary test',
         args: arch)
+
+    cpplint_platform_tag = 'macosx_' + get_option('macosx_version_min').replace('.', '_')
+
     if result.compiled()
         # set options for universal build
         add_global_arguments(arch, language: languages)
         add_global_link_arguments(arch, language: languages)
+        cpplint_platform_tag += '_universal2'
     else
+        if (cpplint_cpu == 'aarch64')
+            cpplint_cpu = 'arm64'
+        endif
+        cpplint_platform_tag += '_' + cpplint_cpu
         warning('Universal build is disabled since your SDKs do not support it.')
     endif
+else
+    if cpplint_os == 'linux'
+        cpplint_platform_tag = 'linux_'
+    endif
+
+    # Check if libc is musl or not
+    result = cpplint_compiler.run(
+        '''
+        #include <features.h>
+        #include <stdio.h>
+
+        int main(void) {
+        #ifdef __GLIBC__
+        printf("glibc");
+        #else
+        printf("musl");
+        #endif
+        return 0;
+        }
+        ''',
+        name: 'libc test')
+
+    if (result.stdout() == 'musl')
+        message('Use static linked musl.')
+        cpplint_link_args += static_libc_args
+        if cpplint_os == 'linux'
+            cpplint_platform_tag = 'linux_'
+        endif
+    else
+        message('Use dynamic linked glibc.')
+        if cpplint_os == 'linux'
+            # requires glibc 2.29 or later
+            cpplint_platform_tag = 'manylinux_2_29_'
+        endif
+    endif
+    if cpplint_os == 'linux'
+        cpplint_platform_tag += cpplint_cpu
+    endif
 endif
+
+# Generate version info
+conf_data = configuration_data()
+conf_data.set('VERSION', meson.project_version())
+conf_data.set('PLATFORM_TAG', cpplint_platform_tag)
+configure_file(input : 'src/version.h.in',
+               output : 'version.h',
+               configuration : conf_data)
 
 # enable JIT compiler in pcre2
 cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
 pcre2_jit_supported = (cpplint_cpu in cpu_jit_supported and
-                       cpplint_compiler != 'tcc' and
+                       cpplint_compiler_id != 'tcc' and
                        cpplint_os != 'darwin')
 if pcre2_jit_supported
-    if cpplint_compiler == 'msvc'
+    if cpplint_compiler_id == 'msvc'
         add_global_arguments('/DSUPPORT_JIT', language: ['c', 'cpp'])
     else
         add_global_arguments('-DSUPPORT_JIT', language: ['c', 'cpp'])

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ project('cpplint-cpp', ['c', 'cpp'],
 
 cpplint_link_args = []
 cpplint_c_args = []
-cpplint_os = host_machine.system()
+cpplint_os = target_machine.system()
 cpplint_cpu = target_machine.cpu_family()
 cpplint_compiler = meson.get_compiler('c')
 cpplint_compiler_id = cpplint_compiler.get_id()
@@ -37,7 +37,7 @@ if cpplint_os == 'windows'
             '/LARGEADDRESSAWARE',
             '/INCREMENTAL:NO'
         ]
-        if (not cpplint_is_debug)
+        if not cpplint_is_debug
             # enable lto
             cpplint_c_args += ['/GL']
             cpplint_link_args += ['/OPT:ICF', '/LTCG']
@@ -46,10 +46,10 @@ if cpplint_os == 'windows'
         # don't require shipping the MinGW-w64 DLLs
         cpplint_link_args += static_libc_args
     endif
-    if (cpplint_cpu == 'aarch64')
+    if cpplint_cpu == 'aarch64'
         cpplint_cpu = 'arm64'
     endif
-    if (cpplint_cpu == 'x86_64')
+    if cpplint_cpu == 'x86_64'
         cpplint_cpu = 'amd64'
     endif
     cpplint_platform_tag = 'win_' + cpplint_cpu
@@ -75,17 +75,13 @@ elif cpplint_os == 'darwin'
         add_global_link_arguments(arch, language: languages)
         cpplint_platform_tag += '_universal2'
     else
-        if (cpplint_cpu == 'aarch64')
+        if cpplint_cpu == 'aarch64'
             cpplint_cpu = 'arm64'
         endif
         cpplint_platform_tag += '_' + cpplint_cpu
         warning('Universal build is disabled since your SDKs do not support it.')
     endif
-else
-    if cpplint_os == 'linux'
-        cpplint_platform_tag = 'linux_'
-    endif
-
+elif cpplint_os == 'linux'
     # Check if libc is musl or not
     result = cpplint_compiler.run(
         '''
@@ -103,22 +99,26 @@ else
         ''',
         name: 'libc test')
 
-    if (result.stdout() == 'musl')
+    if result.stdout() == 'musl'
         message('Use static linked musl.')
         cpplint_link_args += static_libc_args
-        if cpplint_os == 'linux'
-            cpplint_platform_tag = 'linux_'
-        endif
+        # built binary works on all linux distributions
+        cpplint_platform_tag = 'linux_'
     else
         message('Use dynamic linked glibc.')
-        if cpplint_os == 'linux'
-            # requires glibc 2.29 or later
-            cpplint_platform_tag = 'manylinux_2_29_'
-        endif
+        # requires glibc 2.29 or later
+        cpplint_platform_tag = 'manylinux_2_29_'
     endif
-    if cpplint_os == 'linux'
-        cpplint_platform_tag += cpplint_cpu
-    endif
+    cpplint_platform_tag += cpplint_cpu
+else
+    # BSD seems to use uname to generate platform tags.
+    # 'uname -s'_'uname -r'_'uname -m'
+    # Idk about other systems tho.
+    version = run_command('uname', '-r').stdout().strip()
+    version = version.replace('.', '_').replace(' ', '_')
+    arch = run_command('uname', '-m').stdout().strip()
+    arch = arch.replace('.', '_').replace(' ', '_')
+    cpplint_platform_tag = cpplint_os + '_' + version + '_' + arch
 endif
 
 # Generate version info

--- a/meson.build
+++ b/meson.build
@@ -127,6 +127,7 @@ endif
 conf_data = configuration_data()
 conf_data.set('VERSION', meson.project_version())
 conf_data.set('PLATFORM_TAG', cpplint_platform_tag)
+conf_data.set('BUILD_TYPE', get_option('buildtype'))
 configure_file(input : 'src/version.h.in',
                output : 'version.h',
                configuration : conf_data)

--- a/presets/release.ini
+++ b/presets/release.ini
@@ -4,4 +4,5 @@ default_library = 'static'
 b_vscrt = 'mt'
 b_ndebug = 'true'
 cpp_rtti = false
-debug = false
+strip = true
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """
 Script to make or install a package.
-You should put the built binary (cpplint-cpp or cpplint-cpp.exe) in ./dist
-before executing setup.py.
+You should copy cpplint-cpp and cpplint-cpp_info.txt
+from a build directory to ./dist before executing setup.py.
 """
 
 from setuptools import setup, find_packages
@@ -9,40 +9,33 @@ import sys
 import platform
 from packaging.tags import sys_tags
 
-# Get architecture
-arch = platform.machine().lower()
-if (arch not in ['amd64', 'x86_64', 'aarch64', 'arm64']):
-    # Only supports amd64 and arm64
-    raise OSError(f'Unsupported CPU architecture: {arch}')
+# Get version and platform tag
+version = "0.0.0"
+plat_name = ''
+version_header = open('dist/version.h').readlines()
+for line in version_header:
+    if not line.startswith('#define'):
+        continue
+    name = line.split()[1]
+    val = line.split()[2][1:-1]
+    if name == 'CPPLINT_VERSION':
+        version = val
+    if name == 'PLATFORM_TAG':
+        plat_name = val
 
-# Get system's platform tag
-tag = list(sys_tags())[0].platform
+if (not plat_name or plat_name == 'unknown'):
+    # Get system's platform tag
+    plat_name = list(sys_tags())[0].platform
 
-# Get exe_path and plat_name
-if sys.platform.startswith('linux'):
-    exe_path = 'dist/cpplint-cpp'
-    if ('musl' in tag):
-        plat_name = tag
-        print(f'Warning: Your platform is not supported officially. ({tag})')
-    else:
-        # Use the minimum required version of glibc
-        plat_name = 'manylinux_2_29_' + arch
-elif sys.platform.startswith('darwin'):
-    exe_path = 'dist/cpplint-cpp'
-    plat_name = 'macosx_10_15_universal2'
-elif sys.platform.startswith('win32'):
+# Get exe_path
+if sys.platform.startswith('win32'):
     exe_path = 'dist/cpplint-cpp.exe'
-    plat_name = tag
-    if (arch == 'arm64'):
-        print(f'Warning: Your platform is not supported officially. ({tag})')
 else:
     exe_path = 'dist/cpplint-cpp'
-    plat_name = tag
-    print(f'Warning: Your platform is not supported officially. ({tag})')
 
 setup(
     name='cpplint-cpp',
-    version='0.2.0',
+    version=version,
     description='C++ reimplementation of cpplint 1.7',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,62 @@
+"""
+Script to make or install a package.
+You should put the built binary (cpplint-cpp or cpplint-cpp.exe) in ./dist
+before executing setup.py.
+"""
+
+from setuptools import setup, find_packages
+import sys
+import platform
+from packaging.tags import sys_tags
+
+# Get architecture
+arch = platform.machine().lower()
+if (arch not in ['amd64', 'x86_64', 'aarch64', 'arm64']):
+    # Only supports amd64 and arm64
+    raise OSError(f'Unsupported CPU architecture: {arch}')
+
+# Get system's platform tag
+tag = list(sys_tags())[0].platform
+
+# Get exe_path and plat_name
+if sys.platform.startswith('linux'):
+    exe_path = 'dist/cpplint-cpp'
+    if ('musl' in tag):
+        plat_name = tag
+        print(f'Warning: Your platform is not supported officially. ({tag})')
+    else:
+        # Use the minimum required version of glibc
+        plat_name = 'manylinux_2_29_' + arch
+elif sys.platform.startswith('darwin'):
+    exe_path = 'dist/cpplint-cpp'
+    plat_name = 'macosx_10_15_universal2'
+elif sys.platform.startswith('win32'):
+    exe_path = 'dist/cpplint-cpp.exe'
+    plat_name = tag
+    if (arch == 'arm64'):
+        print(f'Warning: Your platform is not supported officially. ({tag})')
+else:
+    exe_path = 'dist/cpplint-cpp'
+    plat_name = tag
+    print(f'Warning: Your platform is not supported officially. ({tag})')
+
+setup(
+    name='cpplint-cpp',
+    version='0.2.0',
+    description='C++ reimplementation of cpplint 1.7',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    author='matyalatte',
+    author_email='matyalatte@gmail.com',
+    url='https://github.com/matyalatte/cpplint-cpp',
+    license=open('LICENSE').read(),
+    include_package_data=True,
+    data_files=[
+        ('bin', [exe_path])
+    ],
+    options={
+        'bdist_wheel': {
+            'plat_name': plat_name,
+        },
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """
 Script to make or install a package.
-You should copy cpplint-cpp and cpplint-cpp_info.txt
+You should copy cpplint-cpp and version.h
 from a build directory to ./dist before executing setup.py.
 """
 

--- a/src/cleanse.cpp
+++ b/src/cleanse.cpp
@@ -181,7 +181,7 @@ std::string CleansedLines::ReplaceAlternateTokens(const std::string& line) {
         const std::string& key = GetMatchStr(m_re_result, str, 2);
         const std::string& token = AltTokenToToken(key);
         std::string tail = ((key == "not" || key == "compl") &&
-                            StrIsChar(GetMatchStr(m_re_result, str, 3), ' ')) ? "" : "\\3";
+                            StrIsChar(GetMatchStrView(m_re_result, str, 3), ' ')) ? "" : "\\3";
         // replace the found token
         RegexReplace(RE_PATTERN_ALT_TOKEN_REPLACEMENT,
                      std::string("\\1") + token + tail, &ret, false);

--- a/src/cleanse.cpp
+++ b/src/cleanse.cpp
@@ -109,12 +109,12 @@ CleansedLines::CleanseRawStrings(const std::vector<std::string>& raw_lines) {
                     break;
 
                 delimiter = ")" + GetMatchStr(m_re_result, new_line, 2) + "\"";
-                std::string match_str_3 = GetMatchStr(m_re_result, new_line, 3);
+                std::string_view match_str_3 = GetMatchStrView(m_re_result, new_line, 3);
                 size_t end = match_str_3.find(delimiter);
                 if (end != std::string::npos) {
                     // Raw string ended on same line
                     new_line = match_str_1 + "\"\"" +
-                               match_str_3.substr(end + delimiter.size());
+                               std::string(match_str_3.substr(end + delimiter.size()));
                     delimiter = "";
                 } else {
                     // Start of a multi-line raw string
@@ -218,15 +218,15 @@ std::string CleansedLines::CollapseStrings(const std::string& elided) {
             collapsed += new_elided;
             break;
         }
-        std::string head = GetMatchStr(m_re_result, new_elided, 1);
+        std::string_view head = GetMatchStrView(m_re_result, new_elided, 1);
         bool has_double_quote = new_elided[GetMatchStart(m_re_result, 2)] == '"';
-        std::string tail = GetMatchStr(m_re_result, new_elided, 3);
+        std::string_view tail = GetMatchStrView(m_re_result, new_elided, 3);
 
         if (has_double_quote) {
             // Collapse double quoted strings
             size_t second_quote = tail.find('"');
             if (second_quote != std::string::npos) {
-                collapsed += head + R"("")";
+                collapsed += std::string(head) + R"("")";
                 new_elided = tail.substr(second_quote + 1);
             } else {
                 // Unmatched double quote, don't bother processing the rest
@@ -245,16 +245,17 @@ std::string CleansedLines::CollapseStrings(const std::string& elided) {
             static const regex_code RE_PATTERN_DIGIT =
                 RegexJitCompile(R"(\b(?:0[bBxX]?|[1-9])[0-9a-fA-F]*$)");
             if (RegexJitSearch(RE_PATTERN_DIGIT, head)) {
-                std::string subject = "'" + tail;
+                std::string subject = "'" + std::string(tail);
                 static const regex_code RE_PATTERN_DIGIT2 =
                     RegexCompile(R"(^((?:\'?[0-9a-zA-Z_])*)(.*)$)");
                 RegexMatch(RE_PATTERN_DIGIT2, subject, m_re_result);
-                collapsed += head + StrReplaceAll(GetMatchStr(m_re_result, subject, 1), "'", "");
+                collapsed += std::string(head) +
+                             StrReplaceAll(GetMatchStr(m_re_result, subject, 1), "'", "");
                 new_elided = GetMatchStr(m_re_result, subject, 2);
             } else {
                 size_t second_quote = tail.find("\'");
                 if (second_quote != std::string::npos) {
-                    collapsed += head + "''";
+                    collapsed += std::string(head) + "''";
                     new_elided = tail.substr(second_quote + 1);
                 } else {
                     // Unmatched single quote

--- a/src/cpplint_state.cpp
+++ b/src/cpplint_state.cpp
@@ -60,7 +60,7 @@ thread_local std::ostringstream cout_buffer;
 thread_local std::ostringstream cerr_buffer;
 
 // Flush streams when the buffer size is larger than this value
-static const std::streampos FLUSH_THRESHOLD = 512;
+static const std::streampos FLUSH_THRESHOLD = 1024;
 
 void CppLintState::PrintInfo(const std::string& message) {
     // _quiet does not represent --quiet flag.
@@ -161,3 +161,7 @@ void CppLintState::FlushThreadStream() {
     }
 }
 
+std::string CppLintState::GetErrorStreamAsStr() {
+    std::lock_guard<std::mutex> lock(m_mtx);
+    return cerr_buffer.str();
+}

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -3982,7 +3982,7 @@ void FileLinter::CacheVariables() {
         m_file_extension = &(m_file.extension().string())[1];
     m_all_extensions = m_options.GetAllExtensions();
     m_header_extensions = m_options.GetHeaderExtensions();
-    m_non_header_extensions = m_options.GetNonHeaderExtensions();
+    m_non_header_extensions = SetDiff(m_all_extensions, m_header_extensions);
 }
 
 void FileLinter::CacheVariables(const fs::path& file) {

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -171,8 +171,8 @@ void FileLinter::ParseNolintSuppressions(const std::string& raw_line,
         } else if (no_lint_type == "BEGIN") {
             if (m_error_suppressions.HasOpenBlock()) {
                 Error(linenum, "readability/nolint", 5,
-                      "NONLINT block already defined on line " +
-                      m_error_suppressions.GetOpenBlockStart());
+                      "NOLINT block already defined on line " +
+                      std::to_string(m_error_suppressions.GetOpenBlockStart()));
             }
             ProcessCategory = ProcessCategoryBegin;
         } else if (no_lint_type == "END") {
@@ -1415,7 +1415,7 @@ void FileLinter::CheckOperatorSpacing(const CleansedLines& clean_lines,
             !(GetMatchStrView(m_re_result, line, 1) == "operator" &&
               StrIsChar(GetMatchStrView(m_re_result, line, 2), ';'))) {
         Error(linenum, "whitespace/operators", 3,
-                              "Missing spaces around <<");
+              "Missing spaces around <<");
     }
 
     // We allow no-spaces around >> for almost anything.  This is because
@@ -1773,8 +1773,7 @@ void FileLinter::CheckSpacingForFunctionCallBase(const std::string& line,
         RegexCompile(R"(\w\s*\(\s(?!\s*\\$))");
     static const regex_code RE_PATTERN_PARENS =
         RegexCompile(R"(\(\s+(?!(\s*\\)|\())");
-    if (GetLastNonSpace(fncall) == '\\' &&  // This can avoid the next RegexSearch()
-            RegexSearch(RE_PATTERN_FUNC_PARENS, fncall)) {
+    if (RegexSearch(RE_PATTERN_FUNC_PARENS, fncall)) {
         // a ( used for a fn call
         Error(linenum, "whitespace/parens", 4,
               "Extra space after ( in function call");
@@ -3660,8 +3659,8 @@ void FileLinter::CheckRedundantOverrideOrFinal(const CleansedLines& clean_lines,
     // Check that at most one of "override" or "final" is present, not both
     if (has_error) {
         Error(linenum, "readability/inheritance", 4,
-                              "\"override\" is redundant since function is "
-                              "already declared as \"final\"");
+              "\"override\" is redundant since function is "
+              "already declared as \"final\"");
     }
 }
 
@@ -4021,7 +4020,7 @@ void FileLinter::ProcessFileData(std::vector<std::string>& lines) {
         }
         if (m_error_suppressions.HasOpenBlock()) {
             Error(m_error_suppressions.GetOpenBlockStart(), "readability/nolint", 5,
-                  "NONLINT block never ended");
+                  "NOLINT block never ended");
         }
     }
 

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -2337,7 +2337,7 @@ void FileLinter::CheckIncludeLine(const CleansedLines& clean_lines, size_t linen
         RegexCompile(R"(^(?:[^/]*[A-Z][^/]*\.h|lua\.h|lauxlib\.h|lualib\.h)$)");
     bool match = RegexMatch(RE_PATTERN_INCLUDE_SUBDIR, line, m_re_result);
     if (match) {
-        if (InStrSet(m_header_extensions, GetMatchStr(m_re_result, line, 2)) &&
+        if (m_header_extensions.contains(GetMatchStr(m_re_result, line, 2)) &&
             !RegexMatch(RE_PATTERN_INCLUDE_EXT,
                         GetMatchStr(m_re_result, line, 1))) {
             Error(linenum, "build/include_subdir", 4,
@@ -3991,7 +3991,7 @@ void FileLinter::ProcessFileData(std::vector<std::string>& lines) {
         }
     }
 
-    bool is_header_extension = InStrSet(m_header_extensions, m_file_extension);
+    bool is_header_extension = m_header_extensions.contains(m_file_extension);
 
     if (is_header_extension) {
         m_cppvar = GetHeaderGuardCPPVariable();
@@ -4009,7 +4009,7 @@ void FileLinter::ProcessFileData(std::vector<std::string>& lines) {
     CheckForIncludeWhatYouUse(clean_lines, &include_state);
 
     // Check that the .cc file has included its header if it exists.
-    if (m_options.IsSourceExtension(m_file_extension))
+    if (m_non_header_extensions.contains(m_file_extension))
         CheckHeaderFileIncluded(&include_state);
 
     CheckForNewlineAtEOF(lines);

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -4048,9 +4048,11 @@ void FileLinter::ProcessFile() {
 
         size_t linenum = 1;
         int status = LINE_OK;
+        std::string buffer;
+        buffer.resize(120);
         // Note: We can't use getline cause it trims NUL bytes and a linefeed at EOF.
         while ((status & LINE_EOF) == 0) {
-            std::string line = GetLine(file, &status);
+            std::string line = GetLine(file, &buffer, &status);
             if (!line.empty() && line.back() == '\r') {
                 // line ends with \r.
                 crlf_lines.push_back(linenum);

--- a/src/line_utils.cpp
+++ b/src/line_utils.cpp
@@ -148,8 +148,6 @@ const std::string& CloseExpression(const CleansedLines& clean_lines, size_t* lin
 void FindStartOfExpressionInLine(const std::string& line,
                                  size_t* endpos,
                                  std::stack<char>* stack) {
-    regex_match re_result = RegexCreateMatchData(RE_PATTERN_OPERATOR);
-
     size_t i = *endpos;
     while (i != INDEX_NONE) {
         char c = line[i];

--- a/src/line_utils.cpp
+++ b/src/line_utils.cpp
@@ -2,18 +2,21 @@
 #include <stack>
 #include <string>
 #include "cleanse.h"
+#include "common.h"
 #include "regex_utils.h"
 #include "string_utils.h"
 
 size_t GetIndentLevel(const std::string& line) {
-    static const regex_code RE_PATTERN_INDENT =
-        RegexCompile(R"(^( *)\S)");
-    thread_local regex_match re_result = RegexCreateMatchData(RE_PATTERN_INDENT);
-    bool indent = RegexMatch(RE_PATTERN_INDENT, line, re_result);
-    if (indent)
-        return GetMatchSize(re_result, 1);
-    else
-        return 0;
+    const char* str_p = line.data();
+    while (*str_p == ' ')
+        str_p++;
+    const char c = *str_p;
+    if (c == '\0' || !IS_SPACE(c)) {
+        // matched with ^( *)\S
+        return TO_SIZE(str_p - line.data());
+    }
+    // matched with ^( *)\s
+    return 0;
 }
 
 const regex_code RE_PATTERN_OPERATOR = RegexCompile(R"(\boperator\s*$)");

--- a/src/nest_info.cpp
+++ b/src/nest_info.cpp
@@ -1,5 +1,6 @@
 #include "nest_info.h"
 #include <string>
+#include <string_view>
 #include "cleanse.h"
 #include "file_linter.h"
 #include "line_utils.h"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -15,14 +15,9 @@
 #include "error_suppressions.h"
 #include "regex_utils.h"
 #include "string_utils.h"
+#include "version.h"
 
 namespace fs = std::filesystem;
-
-// The version of cpplint.cpp
-static const char* CPPLINT_CPP_VERSION = "0.2.0";
-
-// The version of cpplint.py
-static const char* ORIGINAL_VERSION = "1.7";
 
 static const char* USAGE[] = {
     "Syntax: cpplint.cpp [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]\n"
@@ -293,8 +288,8 @@ void Options::PrintUsage(const std::string& message) {
 }
 
 static void PrintVersion() {
-    std::cout << "Cpplint.cpp " << CPPLINT_CPP_VERSION <<
-                 " (https://github.com/matyalatte/cpplint.cpp)\n"
+    std::cout << "cpplint-cpp " << CPPLINT_VERSION <<
+                 " " << PLATFORM_TAG << "\n"
                  "Reimplementation of cpplint.py " << ORIGINAL_VERSION << "\n";
     exit(0);
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -727,7 +727,9 @@ bool Options::ProcessConfigOverrides(const fs::path& filename,
                 std::string base_name = basename.string();
                 if (base_name == "")
                     continue;
-                bool match = RegexMatch(exclude, base_name);
+                regex_code regex = RegexCompile(exclude);
+                regex_match result = RegexCreateMatchData(regex);
+                bool match = RegexMatch(regex, base_name, result);
                 if (match) {
                     if (cpplint_state->Quiet()) {
                         // Suppress "Ignoring file" warning when using --quiet.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -553,14 +553,6 @@ std::set<std::string> Options::GetAllExtensions() const {
     return exts;
 }
 
-bool Options::IsHeaderExtension(const std::string& file_extension) const {
-    return InStrSet(GetHeaderExtensions(), file_extension);
-}
-
-bool Options::IsSourceExtension(const std::string& file_extension) const {
-    return InStrSet(GetNonHeaderExtensions(), file_extension);
-}
-
 std::set<std::string> Options::GetHeaderExtensions() const {
     if (m_hpp_headers.size() > 0) {
         return m_hpp_headers;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -32,6 +32,7 @@ static const char* USAGE[] = {
     "                    [--config=filename]\n"
     "                    [--quiet]\n"
     "                    [--version]\n"
+    "                    [--build]\n"
     "                    [--timing]\n"
     "                    [--threads=#]\n"
     "                    <file> [file] ...\n"
@@ -203,6 +204,9 @@ static const char* USAGE[] = {
     "        --headers=hpp,hxx\n"
     "        --headers=hpp\n"
     "\n"
+    "    build\n"
+    "      Display build configuration for cpplint-cpp.\n"
+    "\n"
     "    timing\n"
     "      Display elapsed processing time.\n"
     "\n"
@@ -288,9 +292,15 @@ void Options::PrintUsage(const std::string& message) {
 }
 
 static void PrintVersion() {
-    std::cout << "cpplint-cpp " << CPPLINT_VERSION <<
-                 " " << PLATFORM_TAG << "\n"
+    std::cout << "cpplint-cpp " << CPPLINT_VERSION << "\n"
                  "Reimplementation of cpplint.py " << ORIGINAL_VERSION << "\n";
+    exit(0);
+}
+
+static void PrintBuildConfig() {
+    std::cout << "platform tag: " << PLATFORM_TAG << "\n"
+                 "build type: " << BUILD_TYPE << "\n"
+                 "jit support: " << JIT_SUPPORT << "\n";
     exit(0);
 }
 
@@ -357,6 +367,8 @@ std::vector<fs::path> Options::ParseArguments(int argc, char** argv,
             PrintUsage();
         } else if (opt == "--version") {
             PrintVersion();
+        } else if (opt == "--build") {
+            PrintBuildConfig();
         } else if (opt.starts_with("--output=")) {
             output_format = ArgToValue(opt);
             if (output_format == "junit") {

--- a/src/states.cpp
+++ b/src/states.cpp
@@ -191,7 +191,7 @@ bool NestingState::InTemplateArgumentList(const CleansedLines& clean_lines,
             pos = 0;
             continue;
         }
-        std::string token = GetMatchStr(re_result, line, 1);
+        std::string_view token = GetMatchStrView(re_result, line, 1);
         pos += GetMatchSize(re_result, 0);
 
         // These things do not look like template argument list:
@@ -434,7 +434,7 @@ void NestingState::Update(const CleansedLines& clean_lines,
                 else
                     parent = "class " + classinfo->Name();
                 std::string slots = "";
-                if (!GetMatchStr(m_re_result, line, 3).empty())
+                if (!GetMatchStrView(m_re_result, line, 3).empty())
                     slots = GetMatchStr(m_re_result, line, 3);
                 file_linter->Error(linenum, "whitespace/indent", 3,
                     GetMatchStr(m_re_result, line, 2) + slots + ":" +

--- a/src/states.cpp
+++ b/src/states.cpp
@@ -252,6 +252,9 @@ void NestingState::UpdatePreprocessor(const std::string& line) {
         to #endif.  We still perform lint checks on these lines, but
         these do not affect nesting stack.
     */
+    if (GetFirstNonSpace(line) != '#')
+        return;  // Not a macro
+
     static const regex_code RE_PATTERN_IF_MACRO =
         RegexCompile(R"(^\s*#\s*(if|ifdef|ifndef)\b)");
     static const regex_code RE_PATTERN_ELSE_MACRO =

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -280,14 +280,18 @@ std::string StrReplaceAll(const std::string &str, const std::string& from, const
 std::string StrToLower(const std::string &str) {
     std::string lower = str;
     std::transform(lower.begin(), lower.end(), lower.begin(),
-        [](unsigned char c){ return std::tolower(c); });
+        [](unsigned char c) -> char {
+            return static_cast<char>(std::tolower(c));
+        });
     return lower;
 }
 
 std::string StrToUpper(const std::string &str) {
     std::string upper = str;
     std::transform(upper.begin(), upper.end(), upper.begin(),
-        [](unsigned char c){ return std::toupper(c); });
+        [](unsigned char c) -> char {
+            return static_cast<char>(std::toupper(c));
+        });
     return upper;
 }
 

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -340,3 +340,13 @@ bool StrIsDigit(const std::string& str) noexcept {
         start++;
     return *start == '\0';
 }
+
+bool StrIsDigit(const std::string_view& str) noexcept {
+    if (str.empty()) return false;
+    const char* start = str.data();
+    const char* end = start + str.size();
+    while (start < end && IS_DIGIT(*start)) {
+        ++start;
+    }
+    return start == end;
+}

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -311,14 +311,26 @@ size_t GetFirstNonSpacePos(const std::string& str, size_t pos) noexcept {
     return TO_SIZE(start - &str[0]);
 }
 
-char GetLastNonSpace(const std::string& str, size_t pos) noexcept {
+char GetLastNonSpace(const std::string& str) noexcept {
+    if (str.empty()) return '\0';
     const char* start = str.data();
-    const char* end = &str[pos];
+    const char* end = &str.back();
     while (end >= start && IS_SPACE(*end))
         end--;
     if (end < start)
         return '\0';
     return *end;
+}
+
+size_t GetLastNonSpacePos(const std::string& str) noexcept {
+    if (str.empty()) return INDEX_NONE;
+    const char* start = str.data();
+    const char* end = &str.back();
+    while (end >= start && IS_SPACE(*end))
+        end--;
+    if (end < start)
+        return INDEX_NONE;
+    return TO_SIZE(end - start);
 }
 
 bool StrIsDigit(const std::string& str) noexcept {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -307,6 +307,16 @@ size_t GetFirstNonSpacePos(const std::string& str, size_t pos) noexcept {
     return TO_SIZE(start - &str[0]);
 }
 
+char GetLastNonSpace(const std::string& str, size_t pos) noexcept {
+    const char* start = str.data();
+    const char* end = &str[pos];
+    while (end >= start && IS_SPACE(*end))
+        end--;
+    if (end < start)
+        return '\0';
+    return *end;
+}
+
 bool StrIsDigit(const std::string& str) noexcept {
     if (str.empty()) return false;
     const char* start = &str[0];

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -359,3 +359,13 @@ bool StrIsDigit(const std::string_view& str) noexcept {
     }
     return start == end;
 }
+
+std::set<std::string> SetDiff(const std::set<std::string>& set1,
+                              const std::set<std::string>& set2) {
+    std::set<std::string> difference;
+    std::set_difference(
+        set1.begin(), set1.end(),
+        set2.begin(), set2.end(),
+        std::inserter(difference, difference.begin()));
+    return difference;
+}

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -146,7 +146,8 @@ std::vector<std::string> StrSplit(const std::string& str, size_t max_size) {
     return split;
 }
 
-std::string StrSplitLast(const std::string& str) {
+template <typename STR>
+STR StrSplitLast(const STR& str) {
     if (str.empty())
         return "";
 
@@ -164,8 +165,10 @@ std::string StrSplitLast(const std::string& str) {
     while (!IS_SPACE(*str_p) && str_p >= start)
         str_p--;
 
-    return std::string(str_p + 1, end);
+    return STR(str_p + 1, end);
 }
+template std::string StrSplitLast(const std::string& str);
+template std::string_view StrSplitLast(const std::string_view& str);
 
 std::vector<std::string> StrSplitBy(const std::string &str, const std::string &delimiter) {
     std::string copied = str;
@@ -182,12 +185,14 @@ std::vector<std::string> StrSplitBy(const std::string &str, const std::string &d
     return tokens;
 }
 
-std::set<std::string> ParseCommaSeparetedList(const std::string& str) {
+template <typename STR>
+std::set<std::string> ParseCommaSeparetedList(const STR& str) {
     std::set<std::string> set = {};
-    const char* str_p = &str[0];
+    const char* str_p = str.data();
     const char* start = str_p;
+    const char* end = str_p + str.size();
 
-    while (*str_p != '\0') {
+    while (str_p < end) {
         if (*str_p == ',') {
             std::string item = StrStrip(start, str_p - 1);
             if (item.size() > 0)
@@ -201,6 +206,10 @@ std::set<std::string> ParseCommaSeparetedList(const std::string& str) {
         set.insert(item);
     return set;
 }
+template std::set<std::string>
+ParseCommaSeparetedList<std::string>(const std::string& str);
+template std::set<std::string>
+ParseCommaSeparetedList<std::string_view>(const std::string_view& str);
 
 std::string SetToStr(const std::set<std::string>& set,
                      const std::string& prefix,

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -1,5 +1,4 @@
 #include "string_utils.h"
-#include <ctype.h>
 #include <algorithm>
 #include <cstdint>
 #include <iostream>
@@ -9,9 +8,6 @@
 #include <utility>
 #include <vector>
 #include "common.h"
-
-#define IS_SPACE(c) isspace((uint8_t)(c))
-#define IS_DIGIT(c) isdigit((uint8_t)(c))
 
 std::string StrBeforeChar(const std::string& str, char c) {
     const char* str_p = &str[0];

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,12 @@
+#pragma once
+// Note: You should copy version.h into ./dist before executing setup.py
+//       It reads CPPLINT_VERSION and PLATFORM_TAG for wheel package
+
+// Version of cpplint.cpp
+#define CPPLINT_VERSION "@VERSION@"
+
+// Version of cpplint.py
+#define ORIGINAL_VERSION "1.7"
+
+// Platform tag for pip
+#define PLATFORM_TAG "@PLATFORM_TAG@"

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -10,3 +10,13 @@
 
 // Platform tag for pip
 #define PLATFORM_TAG "@PLATFORM_TAG@"
+
+// "buildtype" option for meson
+#define BUILD_TYPE "@BUILD_TYPE@"
+
+// JIT compiler for regex operations is enabled or not.
+#ifdef SUPPORT_JIT
+#define JIT_SUPPORT "enabled"
+#else
+#define JIT_SUPPORT "disabled"
+#endif

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -40,28 +40,53 @@ class FileLinterTest : public ::testing::Test {
         fs::path file = filename;
         linter = FileLinter(file, &cpplint_state, options);
     }
+
+    void ExpectErrorStr(const char* expected, const char* file, int linenum) {
+        std::string error_str = cpplint_state.GetErrorStreamAsStr();
+        EXPECT_STREQ(expected, error_str.c_str()) << "  line: " << file << "(" << linenum << ")";
+    }
 };
+
+#define EXPECT_ERROR_STR(expected) ExpectErrorStr(expected, __FILE__, __LINE__)
 
 TEST_F(FileLinterTest, NullBytes) {
     filename = "./tests/test_files/nullbytes.c";
     ProcessFile();
-    // Line contains NUL byte.
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(2, cpplint_state.ErrorCount("readability/nul"));
+    const char* expected =
+        "./tests/test_files/nullbytes.c:1:  "
+        "Line contains NUL byte."
+        "  [readability/nul] [5]\n"
+        "./tests/test_files/nullbytes.c:2:  "
+        "Line contains NUL byte."
+        "  [readability/nul] [5]\n";
+    EXPECT_ERROR_STR(expected);
 }
 
 TEST_F(FileLinterTest, InvalidUTF) {
     filename = "./tests/test_files/invalid_utf.c";
     ProcessFile();
-    // Line contains invalid UTF-8
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(2, cpplint_state.ErrorCount("readability/utf8"));
+    const char* expected =
+        "./tests/test_files/invalid_utf.c:1:  "
+        "Line contains invalid UTF-8 (or Unicode replacement character)."
+        "  [readability/utf8] [5]\n"
+        "./tests/test_files/invalid_utf.c:2:  "
+        "Line contains invalid UTF-8 (or Unicode replacement character)."
+        "  [readability/utf8] [5]\n";
+    EXPECT_ERROR_STR(expected);
 }
 
 TEST_F(FileLinterTest, Crlf) {
     filename = "./tests/test_files/crlf.c";
     ProcessFile();
-    // Unexpected \r (^M) found
     EXPECT_EQ(1, cpplint_state.ErrorCount());
     EXPECT_EQ(1, cpplint_state.ErrorCount("whitespace/newline"));
+    const char* expected =
+        "./tests/test_files/crlf.c:1:  "
+        "Unexpected \\r (^M) found; better to use only \\n"
+        "  [whitespace/newline] [1]\n";
+    EXPECT_ERROR_STR(expected);
 }

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -22,7 +22,9 @@ class FileLinterTest : public ::testing::Test {
         filters = "-legal/copyright,-whitespace/ending_newline,+build/include_alpha";
     }
 
-    void TearDown() override {}
+    void TearDown() override {
+        cpplint_state.FlushThreadStream();
+    }
 
     void ProcessFile() {
         ResetFilters();

--- a/tests/lines_test.cpp
+++ b/tests/lines_test.cpp
@@ -21,7 +21,9 @@ class LinesLinterTest : public ::testing::Test {
         ResetFilters("-legal/copyright,-whitespace/ending_newline,+build/include_alpha");
     }
 
-    void TearDown() override {}
+    void TearDown() override {
+        cpplint_state.FlushThreadStream();
+    }
 
     void ProcessLines(std::vector<std::string> lines) {
         linter.CacheVariables(filename);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,7 +1,7 @@
 test_cpp_args = []
 
 if cpplint_os == 'windows'
-    if cpplint_compiler == 'msvc'
+    if cpplint_compiler_id == 'msvc'
         test_cpp_args += ['/source-charset:utf-8']
     else
         test_cpp_args += ['-finput-charset=UTF-8']

--- a/tests/regex_test.cpp
+++ b/tests/regex_test.cpp
@@ -6,7 +6,7 @@
 
 struct RegexCase {
     const char* pattern;
-    const char* str;
+    const std::string str;
     bool expected;
 };
 
@@ -145,6 +145,6 @@ TEST(RegexTest, RegexReplaceNoCopy) {
 }
 
 TEST(RegexTest, RegexMatchWithRange) {
-    bool match = RegexMatchWithRange("^test$", "rangetest", 5, 4);
+    bool match = RegexMatchWithRange("^test$", std::string("rangetest"), 5, 4);
     EXPECT_EQ(true, match);
 }

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -237,6 +237,8 @@ TEST(StringTest, GetFirstNonSpace) {
 TEST(StringTest, GetFirstNonSpacePos) {
     size_t res = GetFirstNonSpacePos(" \t\r\n\v\fa");
     EXPECT_EQ(6, res);
+    res = GetFirstNonSpacePos("a \t\r\n\v\fa");
+    EXPECT_EQ(0, res);
     res = GetFirstNonSpacePos("");
     EXPECT_EQ(INDEX_NONE, res);
 }
@@ -248,4 +250,26 @@ TEST(StringTest, StrIsBlank) {
     EXPECT_EQ(true, res);
     res = StrIsBlank(" a");
     EXPECT_EQ(false, res);
+}
+
+TEST(StringTest, GetLastNonSpace) {
+    char res = GetLastNonSpace("a \t\r\n\v\f");
+    EXPECT_EQ('a', res);
+    res = GetLastNonSpace("\t\r\n\v\fa");
+    EXPECT_EQ('a', res);
+    res = GetLastNonSpace("");
+    EXPECT_EQ('\0', res);
+}
+
+TEST(StringTest, GetLastNonSpacePos) {
+    size_t res = GetLastNonSpacePos("a \t\r\n\v\f");
+    EXPECT_EQ(0, res);
+    res = GetLastNonSpacePos("a \t\r\n\v\fa");
+    EXPECT_EQ(7, res);
+    res = GetLastNonSpacePos("");
+    EXPECT_EQ(INDEX_NONE, res);
+}
+
+TEST(StringTest, StrContain) {
+    EXPECT_EQ(true, StrContain("x = sprintf()", "printf"));
 }

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -135,7 +135,7 @@ TEST(StringTest, StrSplitTwo) {
 }
 
 TEST(StringTest, StrSplitLast) {
-    std::string res = StrSplitLast("test foo bar");
+    std::string res = StrSplitLast(std::string("test foo bar"));
     EXPECT_STREQ("bar", res.c_str());
 }
 
@@ -163,7 +163,7 @@ TEST(StringTest, ParseCommaSeparetedList) {
     std::set<std::string> expected =
         { "a", "b", "see", "d"};
     std::set<std::string> actual =
-        ParseCommaSeparetedList("a,b, see ,,d");
+        ParseCommaSeparetedList(std::string("a,b, see ,,d"));
     ASSERT_EQ(expected.size(), actual.size());
     auto ex_it = expected.begin();
     auto ac_it = actual.begin();


### PR DESCRIPTION
## pip support

I added `setup.py` to make wheel packages for pip. It can read `version.h` to get version info and platform tag. You can build them with the following commands.

```sh
meson setup build --native-file=presets/release.ini
meson compile -C build
mkdir dist
cp ./build/cpplint-cpp ./dist
cp ./build/version.h ./dist
python -m build
```

When you push a git tag, `build_whl.yml` runs the commands and upload built packages to a release draft. You can install them via pip with `--find-links` option.

```
pip install cpplint-cpp --find-links https://github.com/matyalatte/cpplint-cpp/releases/tag/v0.2.1
```

## Other changes

- Confirmed that error messages were correct. (bec790b16970fa4e8594dcbea6bcab636282cdf7)
- Used std::string_view instead of std::string to avoid memory allocations.
- Fixed an error when using complex regex pattern in CPPLINT.cfg (afec9d64d11e5e21d5f0fe91f95bb389f44b7dc2)
- Added some redundant string checks to avoid complex regex matching. (a5443adcbbc713528daa7703f556e4035ea3a516)
- Added `char GetLastNonSpace(str)` to check simple patterns like `x\s*$` without regex module. (7a0986826ca674c1112f22347f9d4f190b7109ff)
- And more small changes for optimization.