### PR TITLE
Support unix convention of using `-` for stdin.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0 (Unreleased)
+
+- Fixed a bug where `latch` and `numbers` were not considered as c++ headers, courtesy of @GermanAizek. (https://github.com/matyalatte/cpplint-cpp/pull/6)
+- `--exclude` now supports glob patterns. (https://github.com/matyalatte/cpplint-cpp/pull/9)
+- Fixed a compile error on Ubuntu20.04 with an old version of GCC. (https://github.com/matyalatte/cpplint-cpp/pull/12)
+- Added support for unix convention of using `-` for stdin. (https://github.com/matyalatte/cpplint-cpp/pull/13)
+
 ## 0.2.1 (2024-08-25)
 
 - Initial release for cpplint-cpp.


### PR DESCRIPTION
You can use `-` to read code from stdin.

```console
$ echo "int a = (int)1.0;" | cpplint-cpp -
Done processing -
-:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
-:1:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
Total errors found: 2
```