### PR TITLE
Disable readability/fn_size by default

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -45,6 +45,7 @@ class Filter {
 // All entries here should start with a '-' or '+', as in the --filter= flag.
 const std::vector<Filter> DEFAULT_FILTERS = {
     Filter("-build/include_alpha"),
+    Filter("-readability/fn_size"),
 };
 
 enum : int {

--- a/tests/lines_test.cpp
+++ b/tests/lines_test.cpp
@@ -18,7 +18,8 @@ class LinesLinterTest : public ::testing::Test {
 
     void SetUp() override {
         filename = "test/test.cpp";
-        ResetFilters("-legal/copyright,-whitespace/ending_newline,+build/include_alpha");
+        ResetFilters("-legal/copyright,-whitespace/ending_newline,"
+                     "+build/include_alpha,+readability/fn_size");
     }
 
     void TearDown() override {


### PR DESCRIPTION
Applied https://github.com/cpplint/cpplint/commit/820df48adb3cdd557759c5e34d66533680f0b290.
`readability/fn_size` was disabled, as the style guide says "no hard limit is placed on function length."