### PR TITLE
use standard fixed-width typenames for cast checks

### DIFF
--- a/include/file_linter.h
+++ b/include/file_linter.h
@@ -255,7 +255,7 @@ class FileLinter {
     Checks rules from the 'C++ language rules' section of cppguide.html.
 
     Some of these rules are hard to test (function overloading, using
-    uint32 inappropriately), but we do the best we can.
+    uint32_t inappropriately), but we do the best we can.
     */
     void CheckLanguage(const CleansedLines& clean_lines,
                        const std::string& elided_line, size_t linenum,

--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -2517,7 +2517,7 @@ void FileLinter::CheckCasts(const CleansedLines& clean_lines,
     // probably a member operator declaration or default constructor.
     static const regex_code RE_PATTERN_CAST =
         RegexJitCompile(R"((\bnew\s+(?:const\s+)?|\S<\s*(?:const\s+)?)?\b)"
-                        R"((int|float|double|bool|char|int32|uint32|int64|uint64))"
+                        R"((int|float|double|bool|char|int16_t|uint16_t|int32_t|uint32_t|int64_t|uint64_t))"
                         R"((\([^)].*))");
     bool match = RegexJitSearch(RE_PATTERN_CAST, line, m_re_result);
     bool expecting_function = ExpectingFunctionArgs(clean_lines, elided_line, linenum);
@@ -2565,7 +2565,7 @@ void FileLinter::CheckCasts(const CleansedLines& clean_lines,
 
     if (!expecting_function) {
         static const regex_code RE_PATTERN_STATIC_CAST =
-            RegexCompile(R"(\((int|float|double|bool|char|u?int(16|32|64)|size_t)\))");
+            RegexCompile(R"(\((int|float|double|bool|char|u?int(16|32|64)_t|size_t)\))");
         CheckCStyleCast(clean_lines,
                         elided_line, linenum, "static_cast",
                         RE_PATTERN_STATIC_CAST);
@@ -2866,7 +2866,7 @@ void FileLinter::CheckLanguage(const CleansedLines& clean_lines,
         match = RegexSearch(RE_PATTERN_CINT, line, m_re_result);
         if (match) {
             Error(linenum, "runtime/int", 4,
-                  "Use int16/int64/etc, rather than the C type " +
+                  "Use int16_t/int64_t/etc, rather than the C type " +
                   GetMatchStr(m_re_result, line, 1));
         }
     }
@@ -3355,7 +3355,7 @@ void FileLinter::CheckForNonStandardConstructs(const CleansedLines& clean_lines,
     static const regex_code RE_PATTERN_STORAGE_CLASS =
         RegexJitCompile(R"(\b(const|volatile|void|char|short|int|long)"
                      "|float|double|signed|unsigned"
-                     "|schar|u?int8|u?int16|u?int32|u?int64)"
+                     "|schar|u?int8_t|u?int16_t|u?int32_t|u?int64_t)"
                      R"(\s+(register|static|extern|typedef)\b)");
     if (RegexJitSearch(RE_PATTERN_STORAGE_CLASS, elided)) {
         Error(linenum, "build/storage_class", 5,

--- a/tests/lines_test.cpp
+++ b/tests/lines_test.cpp
@@ -2230,9 +2230,9 @@ TEST_F(LinesLinterTest, CastCstyleFail) {
         "int a = (int)1.0;",
         "int a = (int)-1.0;",
         "int *a = (int *)NULL;",
-        "uint16 a = (uint16)1.0;",
-        "int32 a = (int32)1.0;",
-        "uint64 a = (uint64)1.0;",
+        "uint16_t a = (uint16_t)1.0;",
+        "int32_t a = (int32_t)1.0;",
+        "uint64_t a = (uint64_t)1.0;",
         "size_t a = (size_t)1.0;",
         "char *a = (char *) \"foo\";",
     });
@@ -2250,13 +2250,13 @@ TEST_F(LinesLinterTest, CastCstyleFail) {
         "Using C-style cast.  Use reinterpret_cast<int *>(...) instead"
         "  [readability/casting] [4]\n"
         "test/test.cpp:4:  "
-        "Using C-style cast.  Use static_cast<uint16>(...) instead"
+        "Using C-style cast.  Use static_cast<uint16_t>(...) instead"
         "  [readability/casting] [4]\n"
         "test/test.cpp:5:  "
-        "Using C-style cast.  Use static_cast<int32>(...) instead"
+        "Using C-style cast.  Use static_cast<int32_t>(...) instead"
         "  [readability/casting] [4]\n"
         "test/test.cpp:6:  "
-        "Using C-style cast.  Use static_cast<uint64>(...) instead"
+        "Using C-style cast.  Use static_cast<uint64_t>(...) instead"
         "  [readability/casting] [4]\n"
         "test/test.cpp:7:  "
         "Using C-style cast.  Use static_cast<size_t>(...) instead"
@@ -2273,8 +2273,8 @@ TEST_F(LinesLinterTest, CastDeprecatedPass) {
         "int a = int();",
         "X::X() : a(int()) {}",
         "operator bool();",
-        "new int64(123);",
-        "new   int64(123);",
+        "new int64_t(123);",
+        "new   int64_t(123);",
         "new const int(42);",
         "using a = bool(int arg);",
         "x = bit_cast<double(*)[3]>(y);",
@@ -2296,7 +2296,7 @@ TEST_F(LinesLinterTest, CastDeprecatedPass) {
         "typedef bool(MyClass::*MemberFunctionPointer)() const;",
         "void Function(bool(FunctionPointerArg)());",
         "void Function(bool(FunctionPointerArg)()) {}",
-        "typedef set<int64, bool(*)(int64, int64)> SortedIdSet",
+        "typedef set<int64_t, bool(*)(int64_t, int64_t)> SortedIdSet",
         "bool TraverseNode(T *Node, bool(VisitorBase:: *traverse) (T *t)) {}",
     });
     EXPECT_EQ(0, cpplint_state.ErrorCount());
@@ -2659,7 +2659,7 @@ TEST_F(LinesLinterTest, IntPortFail) {
 TEST_F(LinesLinterTest, IntDeclarationPass) {
     ProcessLines({
         "long double b = 65.0;",
-        "int64 a = 65;",
+        "int64_t a = 65;",
     });
     EXPECT_EQ(0, cpplint_state.ErrorCount());
 }
@@ -2673,10 +2673,10 @@ TEST_F(LinesLinterTest, IntDeclarationFail) {
     EXPECT_EQ(2, cpplint_state.ErrorCount("runtime/int"));
     const char* expected =
         "test/test.cpp:1:  "
-        "Use int16/int64/etc, rather than the C type long"
+        "Use int16_t/int64_t/etc, rather than the C type long"
         "  [runtime/int] [4]\n"
         "test/test.cpp:2:  "
-        "Use int16/int64/etc, rather than the C type long"
+        "Use int16_t/int64_t/etc, rather than the C type long"
         "  [runtime/int] [4]\n";
     EXPECT_ERROR_STR(expected);
 }
@@ -3256,7 +3256,7 @@ TEST_F(LinesLinterTest, StorageClass) {
         "const int static foo = 5;",
         "char static foo;",
         "double const static foo = 2.0;",
-        "uint64 typedef unsigned_long_long;",
+        "uint64_t typedef unsigned_long_long;",
         "int register foo = 0;"
     });
     EXPECT_EQ(5, cpplint_state.ErrorCount());
@@ -3854,11 +3854,11 @@ TEST_F(LinesLinterTest, NolintBlockPass) {
 TEST_F(LinesLinterTest, NolintBlockSuppressAll) {
     ProcessLines({
         "// NOLINTBEGIN",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(0, cpplint_state.ErrorCount());
 }
@@ -3866,12 +3866,12 @@ TEST_F(LinesLinterTest, NolintBlockSuppressAll) {
 TEST_F(LinesLinterTest, NolintBlockSuppressAllInBlock) {
     ProcessLines({
         "// NOLINTBEGIN",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
         "// NOLINTEND",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(1, cpplint_state.ErrorCount("readability/casting"));
@@ -3946,14 +3946,14 @@ TEST_F(LinesLinterTest, NolintUnknownCategory) {
 
 TEST_F(LinesLinterTest, NolintLineSuppressAll) {
     ProcessLines({
-        "long a = (int64) 65;  // NOLINT(*)",
+        "long a = (int64_t) 65;  // NOLINT(*)",
     });
     EXPECT_EQ(0, cpplint_state.ErrorCount());
 }
 
 TEST_F(LinesLinterTest, NolintLineSuppressOneCategory) {
     ProcessLines({
-        "long a = (int64) 65;  // NOLINT(runtime/int)",
+        "long a = (int64_t) 65;  // NOLINT(runtime/int)",
     });
     EXPECT_EQ(1, cpplint_state.ErrorCount());
     EXPECT_EQ(1, cpplint_state.ErrorCount("readability/casting"));
@@ -3962,8 +3962,8 @@ TEST_F(LinesLinterTest, NolintLineSuppressOneCategory) {
 TEST_F(LinesLinterTest, NolintNextLine) {
     ProcessLines({
         "// NOLINTNEXTLINE",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(1, cpplint_state.ErrorCount("readability/casting"));
@@ -3974,8 +3974,8 @@ TEST_F(LinesLinterTest, LintCFile) {
     ProcessLines({
         // This suppress readability/casting
         "// LINT_C_FILE",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(2, cpplint_state.ErrorCount("runtime/int"));
@@ -3986,8 +3986,8 @@ TEST_F(LinesLinterTest, LintCFileMultiline) {
         // This suppress readability/casting
         "/* LINT_C_FILE",
         "*/",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(2, cpplint_state.ErrorCount("runtime/int"));
@@ -3997,8 +3997,8 @@ TEST_F(LinesLinterTest, VimMode) {
     ProcessLines({
         // This suppress readability/casting
         "// vim: sw=8 filetype=c ts=8",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(2, cpplint_state.ErrorCount("runtime/int"));
@@ -4008,8 +4008,8 @@ TEST_F(LinesLinterTest, VimMode2) {
     ProcessLines({
         // This suppresses readability/casting
         "// vi: sw=8 filetype=c ts=8",
-        "long a = (int64) 65;",
-        "long a = (int64) 65;",
+        "long a = (int64_t) 65;",
+        "long a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(2, cpplint_state.ErrorCount("runtime/int"));
@@ -4020,7 +4020,7 @@ TEST_F(LinesLinterTest, LintKernelFile) {
         // This suppresses whitespace/tab
         "// LINT_KERNEL_FILE",
         "\t\tint a = 0;",
-        "\t\tlong a = (int64) 65;",
+        "\t\tlong a = (int64_t) 65;",
     });
     EXPECT_EQ(2, cpplint_state.ErrorCount());
     EXPECT_EQ(1, cpplint_state.ErrorCount("readability/casting"));


### PR DESCRIPTION
Applied https://github.com/cpplint/cpplint/commit/b2d18ad23520516bec56f360404732e05bd385d1.
Replaced `int??` with `int??_t` for cast checks.