### PR TITLE
Fix false positive on concept declaration

### DIFF
--- a/src/file_linter.cpp
+++ b/src/file_linter.cpp
@@ -894,6 +894,8 @@ void FileLinter::CheckTrailingSemicolon(const CleansedLines& clean_lines,
                 RegexCompile(R"(\b(?:struct|union)\s+alignas\s*$)");
             static const regex_code RE_PATTERN_DECLTYPE =
                 RegexCompile(R"(\bdecltype$)");
+            static const regex_code RE_PATTERN_REQUIRES =
+                RegexCompile(R"(\brequires.*$)");
             static const regex_code RE_PATTERN_INCOP =
                 RegexCompile(R"(\s+=\s*$)");
             if ((macro && !InStrVec({
@@ -905,6 +907,7 @@ void FileLinter::CheckTrailingSemicolon(const CleansedLines& clean_lines,
                                 GetMatchStrView(func_m, line_prefix, 1))) ||
                     RegexSearch(RE_PATTERN_ALIGNAS, line_prefix) ||
                     RegexSearch(RE_PATTERN_DECLTYPE, line_prefix) ||
+                    RegexSearch(RE_PATTERN_REQUIRES, line_prefix) ||
                     RegexSearch(RE_PATTERN_INCOP, line_prefix)) {
                 match = false;
             }

--- a/tests/lines_test.cpp
+++ b/tests/lines_test.cpp
@@ -730,6 +730,25 @@ TEST_F(LinesLinterTest, TrailingSemicolonPass) {
         "func = []() {",
         "    func();",
         "};",
+        "file_tocs_[i] = (FileToc) {a, b, c};",
+        "class X : public Y,", "public Z {};",
+    });
+    EXPECT_EQ(0, cpplint_state.ErrorCount());
+}
+
+TEST_F(LinesLinterTest, TrailingSemicolonWithConceptPass) {
+    ProcessLines({
+        "#include <algorithm>",
+        "template<typename T>",
+        "concept C = requires(T a, T b) {",
+        "    requires a == b;",
+        "};",
+        "template <typename T, typename U>",
+        "concept C = (std::integral<T> || std::floating_point<T>) &&",
+        "            (std::integral<U> || std::floating_point<U>) &&",
+        "            requires(T t, U u) {",
+        "    std::min(static_cast<float>(t), static_cast<float>(u));",
+        "};",
     });
     EXPECT_EQ(0, cpplint_state.ErrorCount());
 }


### PR DESCRIPTION
Applied https://github.com/cpplint/cpplint/commit/b29d3ee08e5ba1585506f220e588e2d2907f3bf7.
cpplint-cpp now ignores the `requires` expression for concept declaration when checking trailing semicolons.