### PR TITLE
Conform to cpplint 2.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Copy gooletest, Download cpplint.py
         run: |
           cp -r subprojects/googletest-${{ env.GTEST_VER }} ../
-          curl -O https://raw.githubusercontent.com/cpplint/cpplint/ab7335bcc734f6d21226631060888bfb77bbc9d7/cpplint.py
+          curl -O https://raw.githubusercontent.com/cpplint/cpplint/refs/tags/2.0.0/cpplint.py
 
       - name: Show CPU info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.10'
       - run: pip3 install cpplint codespell
       - run: |
-          cpplint --recursive --quiet --filter=-build/c++11,-build/c++17,-readability/nolint,-runtime/printf_format .
+          cpplint --recursive --quiet --filter=-readability/nolint .
           codespell
 
   test:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.0 (Unreleased)
 
+- cpplint-cpp now conforms to [cpplint 2.0](https://github.com/cpplint/cpplint/tree/2.0.0).
+  - Disabled readability/fn_size by default. (https://github.com/matyalatte/cpplint-cpp/pull/14)
+  - Cast checks now uses standard fixed-width typenames. (https://github.com/matyalatte/cpplint-cpp/pull/15)
+  - Fixed false positives on concept declaration. (https://github.com/matyalatte/cpplint-cpp/pull/16)
 - Fixed a bug where `latch` and `numbers` were not considered as c++ headers, courtesy of @GermanAizek. (https://github.com/matyalatte/cpplint-cpp/pull/6)
 - `--exclude` now supports glob patterns. (https://github.com/matyalatte/cpplint-cpp/pull/9)
 - Fixed a compile error on Ubuntu20.04 with an old version of GCC. (https://github.com/matyalatte/cpplint-cpp/pull/12)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ cpplint-cpp is an open-source project that warmly welcomes contributions. We app
 The following types of changes are not acceptable. Before you start contributing, ensure that your work does not involve the following:
 
 - Adding support for new coding rules that cpplint.py does not support.
-- Breaking compatibility with [cpplint.py 1.7](https://github.com/cpplint/cpplint/tree/ab7335bcc734f6d21226631060888bfb77bbc9d7).
+- Breaking compatibility with [cpplint.py 2.0](https://github.com/cpplint/cpplint/tree/2.0.0).
 - Making extensive algorithm changes that would make it difficult for cpplint.py users to read the source code.
 - Implementing platform-specific optimizations (e.g., using SIMD extensions).
 
@@ -38,7 +38,7 @@ cpplint-cpp should maintain compatibility with cpplint.py. For the same file, th
 
 No merge request may be merged until it passes the following code checks:
 
-- Linting by cpplint.py 1.7 (or cpplint-cpp)
+- Linting by cpplint.py 2.0 (or cpplint-cpp)
 - Typo check by [codespell](https://github.com/codespell-project/codespell)
 - Unit tests with `meson test -C build`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-green.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-C++ reimplementation of [cpplint 1.7](https://github.com/cpplint/cpplint/tree/ab7335bcc734f6d21226631060888bfb77bbc9d7)
+C++ reimplementation of [cpplint 2.0](https://github.com/cpplint/cpplint/tree/2.0.0)
 
 ## What is cpplint?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,8 @@ You can see `cpplint-cpp` has significantly better performance, being over 30 ti
 
 |             | googletest-1.14.0 (s) | cpplint-cpp (s) |
 | ----------- | --------------------- | --------------- |
-| cpplint-cpp | 0.443100              | 0.090062        |
-| cpplint.py  | 25.826862             | 3.865572        |
+| cpplint-cpp | 0.439020              | 0.092547        |
+| cpplint.py  | 21.639285             | 3.782867        |
 
 ### Memory usage
 
@@ -38,8 +38,8 @@ Despite using multithreading with 4 cores, `cpplint-cpp` has lower memory usage 
 
 |             | googletest-1.14.0 | cpplint-cpp |
 | ----------- | ----------------- | ----------- |
-| cpplint-cpp | 15.55 MiB         | 10.32 MiB   |
-| cpplint.py  | 23.01 MiB         | 22.43 MiB   |
+| cpplint-cpp | 15.46 MiB         | 10.45 MiB   |
+| cpplint.py  | 23.08 MiB         | 22.57 MiB   |
 
 ## Changes from cpplint.py
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ else:
 setup(
     name='cpplint-cpp',
     version=version,
-    description='C++ reimplementation of cpplint 1.7',
+    description='C++ reimplementation of cpplint 2.0',
     long_description=open('docs/README.md').read(),
     long_description_content_type='text/markdown',
     author='matyalatte',

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -6,7 +6,7 @@
 #define CPPLINT_VERSION "@VERSION@"
 
 // Version of cpplint.py
-#define ORIGINAL_VERSION "1.7"
+#define ORIGINAL_VERSION "2.0"
 
 // Platform tag for pip
 #define PLATFORM_TAG "@PLATFORM_TAG@"


### PR DESCRIPTION
- Replaced `cpplint 1.7` with `cpplint 2.0` in documents.
- CI workflows now uses cpplint 2.0.