### PR TITLE
ignore include order in CI workflow

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -7,9 +7,6 @@ linelength=100
 # Allow to include headers without directories
 filter=-build/include_subdir
 
-# Check include orders
-filter=+build/include_alpha
-
 # No need copyrights
 filter=-legal/copyright
 


### PR DESCRIPTION
I don't think we need a strict rule for the order of including headers.